### PR TITLE
Upgrade to latest spotless plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ generateexamples: $(PROTOC) buildplugin ## Generate proto files for example apps
 
 .PHONY: help
 help: ## Describe useful make targets.
-	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
 
 .PHONY: installandroid
 installandroid: ## Install the example Android app.
@@ -106,7 +106,7 @@ lint: ## Run lint.
 	./gradlew $(GRADLE_ARGS) spotlessCheck
 
 .PHONY: lintfix
-lintfix: # Applies the lint changes.
+lintfix: ## Applies the lint changes.
 	./gradlew $(GRADLE_ARGS) spotlessApply
 
 .PHONY: release

--- a/conformance/common/src/main/kotlin/com/connectrpc/conformance/ssl/SSL.kt
+++ b/conformance/common/src/main/kotlin/com/connectrpc/conformance/ssl/SSL.kt
@@ -29,14 +29,14 @@ import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 
 fun sslContext(): Pair<SSLSocketFactory, X509TrustManager> {
-    val certificate = clientCert.byteInputStream(Charsets.UTF_8).use { stream ->
+    val certificate = CLIENT_CERT.byteInputStream(Charsets.UTF_8).use { stream ->
         CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
     }
-    val certificateAuthority = conformanceCACert.byteInputStream(Charsets.UTF_8).use { stream ->
+    val certificateAuthority = CONFORMANCE_CA_CERT.byteInputStream(Charsets.UTF_8).use { stream ->
         CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
     }
     val publicKey = certificate.getPublicKey() as RSAPublicKey
-    val clientKeyBytes = clientKey
+    val clientKeyBytes = CLIENT_KEY
         .replace("-----(BEGIN|END) PRIVATE KEY-----".toRegex(), "")
         .replace("\r?\n".toRegex(), "")
         .encodeUtf8()
@@ -58,7 +58,7 @@ fun sslContext(): Pair<SSLSocketFactory, X509TrustManager> {
 
 // https://github.com/connectrpc/conformance/blob/main/cert/client.crt
 // cert issues: https://stackoverflow.com/questions/9210514/unable-to-find-valid-certification-path-to-requested-target-error-even-after-c
-private const val clientCert = """-----BEGIN CERTIFICATE-----
+private const val CLIENT_CERT = """-----BEGIN CERTIFICATE-----
 MIIEODCCAiCgAwIBAgIRAJTCeo42f8lts3VeDnN7CVwwDQYJKoZIhvcNAQELBQAw
 FjEUMBIGA1UEAxMLQ3Jvc3N0ZXN0Q0EwHhcNMjIwNTAzMTcxMDQwWhcNMjMxMTAz
 MTcxOTU2WjARMQ8wDQYDVQQDEwZjbGllbnQwggEiMA0GCSqGSIb3DQEBAQUAA4IB
@@ -86,7 +86,7 @@ g+mJcflVCfjEqJzfEy4wPq5SJzOIzXva6DyBpA==
 
 // https://github.com/connectrpc/conformance/blob/main/cert/ConformanceCA.crt
 // Certificate authority for the trusted cert.
-private const val conformanceCACert = """-----BEGIN CERTIFICATE-----
+private const val CONFORMANCE_CA_CERT = """-----BEGIN CERTIFICATE-----
 MIIE7DCCAtSgAwIBAgIBATANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDEwtDcm9z
 c3Rlc3RDQTAeFw0yMjA1MDMxNzA5NTlaFw0yMzExMDMxNzE5NTZaMBYxFDASBgNV
 BAMTC0Nyb3NzdGVzdENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA
@@ -120,7 +120,7 @@ iQ8d6tGEgzeekht617JMvQ==
 // openssl pkey -in key.pem -out outkey.pem
 // (alt: openssl pkcs8 -topk8 -nocrypt -in key.pem -out output)
 // https://stackoverflow.com/questions/68926722/how-to-read-a-certificate-chain-for-okhttpclient
-private const val clientKey = """-----BEGIN PRIVATE KEY-----
+private const val CLIENT_KEY = """-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCoJI6BDesWPERm
 7zjLGA9Pp0XSR3rnpecXTKIBwamr35gr/It4jAZMMBUBHhdvLB0pAj1/hlWLvDQS
 uQBvfsr2KrqOvtVOP0c5KCzwHjvLmyhhvjOV5iEdtv5mUDwILcQH8mvK4XTyWqID
@@ -148,32 +148,3 @@ TssOSwdX1A27uW63CjrGQ3eVC6qaeWjTJ8XrmIxdayD6gDMNp4p4tnuB5Nw03dNa
 YfnVHhS0VV49dKIqrsP8o1qZJRhjcq/J/Rrm2ZFHfdLCOOnd9VG4W2I1WB9MDc4t
 raq4CptHPEywZgBR95C0Jv3y
 -----END PRIVATE KEY-----"""
-
-// https://github.com/connectrpc/conformance/blob/main/cert/client.key
-const val rsaClientKey = """-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAqCSOgQ3rFjxEZu84yxgPT6dF0kd656XnF0yiAcGpq9+YK/yL
-eIwGTDAVAR4XbywdKQI9f4ZVi7w0ErkAb37K9iq6jr7VTj9HOSgs8B47y5soYb4z
-leYhHbb+ZlA8CC3EB/JryuF08lqiA77JVLNysVn7sKzx2RPqqbVQBPfNqW2IsUE0
-xsp0SovrZRam9GtO9JKCruY4/sdk1eioIeEhZnsR3QUmFohJVBgJLNjCdPQk+fg7
-2s+JXjxpQOlZQyI8In/5c4hwEgb1vuieGaS8gHgnPtfw4CO+BpqctqDRpm9iwTMK
-zDmS+SrHYjMmGPWYz5ilnMcm44Bj34p23LTpXQIDAQABAoIBAFaTpDC9SuwDEjFy
-QesJM3EPLztsBNPcL9ZmZhDDeCsAkWksu1/RsbhvFZGivexHaahg9+t+7vNpb+Ko
-EZpXTghczfyMNGb63CCJGEJ3PtDCzpMtjYBEo46aV/m0nISVlBeHcotfdYkIs917
-0kzjrU22iItbMZhV0gGaU16LfgEbiJpMS7nmVKnmLEs02g4G3H+xKXRfRhQA7RId
-OIa/iHkJsNQ+o4MiJ7s4G1hp3zqZBSnHuPM3qqj+MAUHobeJKdB7WCW5UWXI9OmA
-ryRSk+R6KDDoXxyWZc0FQ5BJ0OhwMzBsxgqs54CDWND/PLjmsvOjvdhMqpKRy2Am
-oMXk0J0CgYEA0Mkbhh/M7nEeGwKM8MxovSEE0u0j2ksbgt9Wx2aCfiP6GWxLZZuj
-o1aV7TgEn7M70qyeTs9B/fWVzk+tO0yN0S07VxlaY5RMV44LdHnQ85TeTEIxQIAa
-ZYq3kFdfim9ZVzouZHK4mCqYoKpKQyx0sEjbfm9+tdPbs/x5xzVa5EcCgYEAziqU
-zmopsZM4CnCnqvuKK8GH7WwDZXd7SrMOm2qBuvZxNQZsNNsTLR9SV23YA9yYrkmk
-dqdVRS9WX1HjFgbSrQ19b4nk7GZ3d1pjCIZ0BW+WVI6ZkINRCniCsK/2fakCRyas
-HTF+eZIre7SIjM2SKxQU7EbG1J1Mt3Vh3ilSyzsCgYEAuw1iDmERPhK0ESjQ0q+f
-qsoZQ0vYEiu2IyMq4QyzHoXm/L3sMsUk7yKUwemtItL2ZsHmNt8y1W8f3q29muH0
-MJKglmENfSeQ2eRV2O2GSaR3IMUw0QO0IoMMAFJ3M1SdKyviAnZRcWrAQTkvvUzn
-4kPz+iuzzv1W2cL564KewuMCgYEAuNDXQQtOgQ+Wh1ViGRcRUBRXw/C2QrmPXvGR
-QKWD0pSl+4Dcc62ITUTszc98fEm+3U7LDksHV9QNu7lutwo6xkN3lQuqmnlo0yfF
-65iMXWsg+oAzDaeKeLZ7geTcNN3TWvFCDZGW7WipbmXymzaVt+RytTTlfSfd5ABo
-UX396I0CgYASYF3TgzFVGkQK/lVlTOFaWAf0IZ3qwVfCWlezi4GVDHc+eZ27n8rE
-UPFHgEHm9ID0jun/4FQsUkkWQpvfl2H51R4UtFVePXSiKq7D/KNamSUYY3Kvyf0a
-5tmRR33Swjjp3fVRuFtiNVgfTA3OLa2quAqbRzxMsGYAUfeQtCb98g==
------END RSA PRIVATE KEY-----"""

--- a/conformance/google-java/build.gradle.kts
+++ b/conformance/google-java/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.diffplug.gradle.spotless.SpotlessExtension
-
 plugins {
     application
     java
@@ -36,10 +34,4 @@ dependencies {
     testImplementation(libs.kotlin.coroutines.core)
     testImplementation(libs.testcontainers)
     testImplementation(libs.slf4j.simple)
-}
-
-configure<SpotlessExtension> {
-    kotlin {
-        targetExclude("build/generated/sources/bufgen/**/*.kt")
-    }
 }

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(Parameterized::class)
 class Conformance(
     private val protocol: NetworkProtocol,
-    private val serverType: ServerType
+    private val serverType: ServerType,
 ) {
     private lateinit var connectClient: ProtocolClient
     private lateinit var shortTimeoutConnectClient: ProtocolClient
@@ -75,7 +75,7 @@ class Conformance(
                 arrayOf(NetworkProtocol.CONNECT, ServerType.CONNECT_GO),
                 arrayOf(NetworkProtocol.GRPC, ServerType.CONNECT_GO),
                 arrayOf(NetworkProtocol.GRPC_WEB, ServerType.CONNECT_GO),
-                arrayOf(NetworkProtocol.GRPC, ServerType.GRPC_GO)
+                arrayOf(NetworkProtocol.GRPC, ServerType.GRPC_GO),
             )
         }
 
@@ -92,7 +92,7 @@ class Conformance(
                 "--cert",
                 "cert/localhost.crt",
                 "--key",
-                "cert/localhost.key"
+                "cert/localhost.key",
             )
             .waitingFor(HostPortWaitStrategy().forPorts(8081))
 
@@ -107,7 +107,7 @@ class Conformance(
                 "--cert",
                 "cert/localhost.crt",
                 "--key",
-                "cert/localhost.key"
+                "cert/localhost.key",
             )
             .waitingFor(HostPortWaitStrategy().forPorts(8081))
     }
@@ -132,15 +132,15 @@ class Conformance(
                     .readTimeout(Duration.ofMillis(1))
                     .writeTimeout(Duration.ofMillis(1))
                     .callTimeout(Duration.ofMillis(1))
-                    .build()
+                    .build(),
             ),
             ProtocolClientConfig(
                 host = host,
                 serializationStrategy = GoogleJavaProtobufStrategy(),
                 networkProtocol = protocol,
                 requestCompression = RequestCompression(10, GzipCompressionPool),
-                compressionPools = listOf(GzipCompressionPool)
-            )
+                compressionPools = listOf(GzipCompressionPool),
+            ),
         )
         connectClient = ProtocolClient(
             httpClient = ConnectOkHttpClient(client),
@@ -149,8 +149,8 @@ class Conformance(
                 serializationStrategy = GoogleJavaProtobufStrategy(),
                 networkProtocol = protocol,
                 requestCompression = RequestCompression(10, GzipCompressionPool),
-                compressionPools = listOf(GzipCompressionPool)
-            )
+                compressionPools = listOf(GzipCompressionPool),
+            ),
         )
         testServiceConnectClient = TestServiceClient(connectClient)
         unimplementedServiceClient = UnimplementedServiceClient(connectClient)
@@ -168,7 +168,7 @@ class Conformance(
             31415,
             9,
             2653,
-            58979
+            58979,
         )
         val parameters = sizes.mapIndexed { index, value ->
             responseParameters {
@@ -180,7 +180,7 @@ class Conformance(
         stream.send(
             streamingOutputCallRequest {
                 responseParameters.addAll(parameters)
-            }
+            },
         )
         withContext(Dispatchers.IO) {
             val job = async {
@@ -193,12 +193,12 @@ class Conformance(
                                 assertThat(result.connectError()!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
                                 assertThat(result.connectError()!!.message).isEqualTo("soirée 🎉")
                                 assertThat(result.connectError()!!.unpackedDetails(ErrorDetail::class)).containsExactly(
-                                    expectedErrorDetail
+                                    expectedErrorDetail,
                                 )
                             } finally {
                                 countDownLatch.countDown()
                             }
-                        }
+                        },
                     )
                 }
             }
@@ -258,7 +258,7 @@ class Conformance(
         val headers =
             mapOf(
                 leadingKey to listOf(leadingValue),
-                trailingKey to listOf(b64Encode(trailingValue))
+                trailingKey to listOf(b64Encode(trailingValue)),
             )
         val message = simpleRequest {
             responseSize = size
@@ -319,7 +319,7 @@ class Conformance(
                 responseParameters {
                     size = 31415
                     intervalUs = 50_000
-                }
+                },
             )
         }
         val stream = client.streamingOutputCall()
@@ -335,7 +335,7 @@ class Conformance(
                             } finally {
                                 countDownLatch.countDown()
                             }
-                        }
+                        },
                     )
                 }
             }
@@ -358,7 +358,7 @@ class Conformance(
                     code = 2
                     message = statusMessage
                 }
-            }
+            },
         ) { response ->
             response.failure { errorResponse ->
                 val error = errorResponse.error
@@ -413,7 +413,7 @@ class Conformance(
                             } finally {
                                 countDownLatch.countDown()
                             }
-                        }
+                        },
                     )
                 }
             }
@@ -488,7 +488,7 @@ class Conformance(
         val headers =
             mapOf(
                 leadingKey to listOf(leadingValue),
-                trailingKey to listOf(b64Encode(trailingValue))
+                trailingKey to listOf(b64Encode(trailingValue)),
             )
         val message = simpleRequest {
             responseSize = size
@@ -536,7 +536,7 @@ class Conformance(
                     code = 2
                     message = statusMessage
                 }
-            }
+            },
         ).execute()
         response.failure { errorResponse ->
             val error = errorResponse.error
@@ -630,7 +630,7 @@ class Conformance(
         val headers =
             mapOf(
                 leadingKey to listOf(leadingValue),
-                trailingKey to listOf(b64Encode(trailingValue))
+                trailingKey to listOf(b64Encode(trailingValue)),
             )
         val message = simpleRequest {
             responseSize = size
@@ -690,7 +690,7 @@ class Conformance(
                     code = 2
                     message = statusMessage
                 }
-            }
+            },
         ) { response ->
             response.failure { errorResponse ->
                 val error = errorResponse.error

--- a/conformance/google-javalite/build.gradle.kts
+++ b/conformance/google-javalite/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.diffplug.gradle.spotless.SpotlessExtension
-
 plugins {
     application
     java
@@ -35,10 +33,4 @@ dependencies {
     testImplementation(libs.mockito)
     testImplementation(libs.kotlin.coroutines.core)
     testImplementation(libs.testcontainers)
-}
-
-configure<SpotlessExtension> {
-    kotlin {
-        targetExclude("build/generated/sources/bufgen/**/*.kt")
-    }
 }

--- a/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
+++ b/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
@@ -84,8 +84,8 @@ class ElizaChatActivity : AppCompatActivity() {
             ProtocolClientConfig(
                 host = host,
                 serializationStrategy = GoogleJavaLiteProtobufStrategy(),
-                networkProtocol = selectedNetworkProtocolOption
-            )
+                networkProtocol = selectedNetworkProtocolOption,
+            ),
         )
         // Create the Eliza service client.
         val elizaServiceClient = ElizaServiceClient(client)
@@ -153,10 +153,10 @@ class ElizaChatActivity : AppCompatActivity() {
                         adapter.add(
                             MessageData(
                                 "Session has ended.",
-                                true
-                            )
+                                true,
+                            ),
                         )
-                    }
+                    },
                 )
             }
             lifecycleScope.launch(Dispatchers.Main) {

--- a/examples/android/src/main/kotlin/com/connectrpc/examples/android/RecyclerView.kt
+++ b/examples/android/src/main/kotlin/com/connectrpc/examples/android/RecyclerView.kt
@@ -78,5 +78,5 @@ class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
 data class MessageData(
     val message: String,
-    val isEliza: Boolean
+    val isEliza: Boolean,
 )

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -40,12 +40,12 @@ class Main {
                             .readTimeout(Duration.ofMinutes(10))
                             .writeTimeout(Duration.ofMinutes(10))
                             .callTimeout(Duration.ofMinutes(10))
-                            .build()
+                            .build(),
                     ),
                     ProtocolClientConfig(
                         host = host,
-                        serializationStrategy = GoogleJavaProtobufStrategy()
-                    )
+                        serializationStrategy = GoogleJavaProtobufStrategy(),
+                    ),
                 )
                 val elizaServiceClient = ElizaServiceClient(client)
                 connectStreaming(elizaServiceClient)
@@ -63,7 +63,7 @@ class Main {
                             // Update the view with the response.
                             val elizaResponse = result.message
                             println(elizaResponse.sentence)
-                        }
+                        },
                     )
                 }
             }

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -40,12 +40,12 @@ class Main {
                             .readTimeout(Duration.ofMinutes(10))
                             .writeTimeout(Duration.ofMinutes(10))
                             .callTimeout(Duration.ofMinutes(10))
-                            .build()
+                            .build(),
                     ),
                     ProtocolClientConfig(
                         host = host,
-                        serializationStrategy = GoogleJavaLiteProtobufStrategy()
-                    )
+                        serializationStrategy = GoogleJavaLiteProtobufStrategy(),
+                    ),
                 )
                 val elizaServiceClient = ElizaServiceClient(client)
                 connectStreaming(elizaServiceClient)
@@ -63,7 +63,7 @@ class Main {
                             // Update the view with the response.
                             val elizaResponse = result.message
                             println(elizaResponse.sentence)
-                        }
+                        },
                     )
                 }
             }

--- a/extensions/google-java/build.gradle.kts
+++ b/extensions/google-java/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
     )
 }
 

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
@@ -14,8 +14,8 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_JSON
 import com.connectrpc.Codec
-import com.connectrpc.codecNameJSON
 import com.google.protobuf.GeneratedMessageV3
 import com.google.protobuf.Internal
 import com.google.protobuf.util.JsonFormat
@@ -29,7 +29,7 @@ import kotlin.reflect.KClass
  * deserializing and serializing data types.
  */
 internal class GoogleJavaJSONAdapter<E : GeneratedMessageV3>(
-    clazz: KClass<E>
+    clazz: KClass<E>,
 ) : Codec<E> {
     /**
      * Casting assumes the user is using Google's GeneratedMessageV3 type.
@@ -40,7 +40,7 @@ internal class GoogleJavaJSONAdapter<E : GeneratedMessageV3>(
     }
 
     override fun encodingName(): String {
-        return codecNameJSON
+        return CODEC_NAME_JSON
     }
 
     /**

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONStrategy.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONStrategy.kt
@@ -14,10 +14,10 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_JSON
 import com.connectrpc.Codec
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.SerializationStrategy
-import com.connectrpc.codecNameJSON
 import com.google.protobuf.GeneratedMessageV3
 import kotlin.reflect.KClass
 
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
  */
 class GoogleJavaJSONStrategy : SerializationStrategy {
     override fun serializationName(): String {
-        return codecNameJSON
+        return CODEC_NAME_JSON
     }
 
     /**

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
@@ -14,8 +14,8 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
-import com.connectrpc.codecNameProto
 import com.google.protobuf.CodedOutputStream
 import com.google.protobuf.GeneratedMessageV3
 import com.google.protobuf.Internal
@@ -29,7 +29,7 @@ import kotlin.reflect.KClass
  * deserializing and serializing data types.
  */
 internal class GoogleJavaProtoAdapter<E : GeneratedMessageV3>(
-    clazz: KClass<E>
+    clazz: KClass<E>,
 ) : Codec<E> {
     /**
      * Casting assumes the user is using Google's GeneratedMessageV3 type.
@@ -40,7 +40,7 @@ internal class GoogleJavaProtoAdapter<E : GeneratedMessageV3>(
     }
 
     override fun encodingName(): String {
-        return codecNameProto
+        return CODEC_NAME_PROTO
     }
 
     /**

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtobufStrategy.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtobufStrategy.kt
@@ -14,10 +14,10 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.SerializationStrategy
-import com.connectrpc.codecNameProto
 import com.google.protobuf.GeneratedMessageV3
 import kotlin.reflect.KClass
 
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
  */
 class GoogleJavaProtobufStrategy : SerializationStrategy {
     override fun serializationName(): String {
-        return codecNameProto
+        return CODEC_NAME_PROTO
     }
 
     /**

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/JavaErrorParser.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/JavaErrorParser.kt
@@ -54,7 +54,7 @@ internal object JavaErrorParser : ErrorDetailParser {
                 // Try to decode via base64 and if that fails, use the original value.
                 // Connect unary ends up encoding the payload as base64. GRPC and GRPC-Web
                 // both do not encode this payload as base64 so decodeBase64() returns null.
-                msg.value.toStringUtf8().decodeBase64() ?: msg.value.toStringUtf8().encodeUtf8()
+                msg.value.toStringUtf8().decodeBase64() ?: msg.value.toStringUtf8().encodeUtf8(),
             )
         }
     }

--- a/extensions/google-java/src/test/kotlin/com/connectrpc/extensions/JavaErrorParserTest.kt
+++ b/extensions/google-java/src/test/kotlin/com/connectrpc/extensions/JavaErrorParserTest.kt
@@ -34,7 +34,7 @@ class JavaErrorParserTest {
             .build()
         val serializedError = AnyError(
             "type.googleapis.com/google.rpc.Status",
-            proto.toByteArray().toByteString().base64().encodeUtf8()
+            proto.toByteArray().toByteString().base64().encodeUtf8(),
         )
         val unpacked = parser.unpack(serializedError, Status::class)
         assertThat(unpacked!!.code).isEqualTo(123)
@@ -60,13 +60,13 @@ class JavaErrorParserTest {
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_1")
                     .setValue(ByteString.copyFrom("value_1".encodeUtf8().base64().encodeToByteArray()))
-                    .build()
+                    .build(),
             )
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_2")
                     .setValue(ByteString.copyFrom("value_2".encodeUtf8().base64().encodeToByteArray()))
-                    .build()
+                    .build(),
             )
             .build()
         val details = parser.parseDetails(proto.toByteArray())

--- a/extensions/google-javalite/build.gradle.kts
+++ b/extensions/google-javalite/build.gradle.kts
@@ -29,7 +29,7 @@ sourceSets {
 
 configure<MavenPublishBaseExtension> {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
     )
 }
 

--- a/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleJavaLiteProtobufStrategy.kt
+++ b/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleJavaLiteProtobufStrategy.kt
@@ -14,10 +14,10 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.SerializationStrategy
-import com.connectrpc.codecNameProto
 import com.google.protobuf.GeneratedMessageLite
 import kotlin.reflect.KClass
 
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
  */
 class GoogleJavaLiteProtobufStrategy : SerializationStrategy {
     override fun serializationName(): String {
-        return codecNameProto
+        return CODEC_NAME_PROTO
     }
 
     /**

--- a/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleLiteProtoAdapter.kt
+++ b/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleLiteProtoAdapter.kt
@@ -14,8 +14,8 @@
 
 package com.connectrpc.extensions
 
+import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
-import com.connectrpc.codecNameProto
 import com.google.protobuf.CodedOutputStream
 import com.google.protobuf.GeneratedMessageLite
 import com.google.protobuf.Internal
@@ -30,7 +30,7 @@ import kotlin.reflect.KClass
  * deserializing and serializing data types.
  */
 internal class GoogleLiteProtoAdapter<E : GeneratedMessageLite<out E, *>>(
-    clazz: KClass<E>
+    clazz: KClass<E>,
 ) : Codec<E> {
     /**
      * Casting assumes the user is using Google's MessageLite type.
@@ -41,7 +41,7 @@ internal class GoogleLiteProtoAdapter<E : GeneratedMessageLite<out E, *>>(
     }
 
     override fun encodingName(): String {
-        return codecNameProto
+        return CODEC_NAME_PROTO
     }
 
     override fun deserialize(source: BufferedSource): E {

--- a/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/JavaLiteErrorParser.kt
+++ b/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/JavaLiteErrorParser.kt
@@ -47,7 +47,7 @@ internal object JavaLiteErrorParser : ErrorDetailParser {
             ConnectErrorDetail(
                 type = msg.typeUrl,
                 payload = msg.value.toStringUtf8().decodeBase64()
-                    ?: msg.value.toStringUtf8().encodeUtf8()
+                    ?: msg.value.toStringUtf8().encodeUtf8(),
             )
         }
     }

--- a/extensions/google-javalite/src/test/kotlin/com/connectrpc/extensions/JavaLiteErrorParserTest.kt
+++ b/extensions/google-javalite/src/test/kotlin/com/connectrpc/extensions/JavaLiteErrorParserTest.kt
@@ -34,7 +34,7 @@ class JavaLiteErrorParserTest {
             .build()
         val serializedError = AnyError(
             "type.googleapis.com/com.connectrpc.google.rpc.Status",
-            proto.toByteArray().toByteString().base64().encodeUtf8()
+            proto.toByteArray().toByteString().base64().encodeUtf8(),
         )
         val unpacked = parser.unpack(serializedError, Status::class)
         assertThat(unpacked!!.code).isEqualTo(123)
@@ -60,13 +60,13 @@ class JavaLiteErrorParserTest {
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_1")
                     .setValue(ByteString.copyFrom("value_1".encodeUtf8().base64().encodeToByteArray()))
-                    .build()
+                    .build(),
             )
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_2")
                     .setValue(ByteString.copyFrom("value_2".encodeUtf8().base64().encodeToByteArray()))
-                    .build()
+                    .build(),
             )
             .build()
         val details = parser.parseDetails(proto.toByteArray())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,13 +6,13 @@ dokka = "1.9.0"
 junit = "4.13.2"
 kotlin = "1.9.10"
 kotlinpoet = "1.14.2"
-ktlint = "0.46.0"
 mavenplugin = "0.24.0"
 moshi = "1.15.0"
 okhttp = "4.10.0"
 okio = "3.0.0"
 protobuf = "3.24.3"
 slf4j = "1.7.36"
+spotless = "6.21.0"
 
 [libraries]
 android = { module = "com.google.android:android", version.ref = "android" }
@@ -51,9 +51,10 @@ protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
 protobuf-kotlinlite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.13.0" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 testcontainers = { module = "org.testcontainers:testcontainers", version = "1.19.0" }
 
 [plugins]
 git = { id = "com.palantir.git-version", version = "3.0.0" }
 ksp = { id = "com.google.devtools.ksp", version = "1.9.10-1.0.13" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
     )
 }
 // Workaround for overriding the published library name to "connect-kotlin".

--- a/library/src/main/kotlin/com/connectrpc/AnyError.kt
+++ b/library/src/main/kotlin/com/connectrpc/AnyError.kt
@@ -21,5 +21,5 @@ import okio.ByteString
  */
 class AnyError(
     val typeUrl: String,
-    val value: ByteString = ByteString.EMPTY
+    val value: ByteString = ByteString.EMPTY,
 )

--- a/library/src/main/kotlin/com/connectrpc/Code.kt
+++ b/library/src/main/kotlin/com/connectrpc/Code.kt
@@ -36,7 +36,8 @@ enum class Code(val codeName: String, val value: Int) {
     INTERNAL_ERROR("internal", 13),
     UNAVAILABLE("unavailable", 14),
     DATA_LOSS("data_loss", 15),
-    UNAUTHENTICATED("unauthenticated", 16);
+    UNAUTHENTICATED("unauthenticated", 16),
+    ;
 
     companion object {
         // https://connectrpc.com/docs/protocol#http-to-error-code

--- a/library/src/main/kotlin/com/connectrpc/Codec.kt
+++ b/library/src/main/kotlin/com/connectrpc/Codec.kt
@@ -17,8 +17,16 @@ package com.connectrpc
 import okio.Buffer
 import okio.BufferedSource
 
-const val codecNameProto = "proto"
-const val codecNameJSON = "json"
+const val CODEC_NAME_PROTO = "proto"
+const val CODEC_NAME_JSON = "json"
+
+@Deprecated("replaced with CODEC_NAME_PROTO", ReplaceWith("CODEC_NAME_PROTO"))
+@Suppress("ktlint:standard:property-naming")
+const val codecNameProto = CODEC_NAME_PROTO
+
+@Deprecated("replaced with CODEC_NAME_JSON", ReplaceWith("CODEC_NAME_JSON"))
+@Suppress("ktlint:standard:property-naming")
+const val codecNameJSON = CODEC_NAME_JSON
 
 /**
  * Defines a type that is capable of encoding and decoding messages using a specific format.

--- a/library/src/main/kotlin/com/connectrpc/ConnectError.kt
+++ b/library/src/main/kotlin/com/connectrpc/ConnectError.kt
@@ -31,7 +31,7 @@ data class ConnectError constructor(
     // List of typed errors that were provided by the server.
     val details: List<ConnectErrorDetail> = emptyList(),
     // Additional key-values that were provided by the server.
-    val metadata: Headers = emptyMap()
+    val metadata: Headers = emptyMap(),
 ) : Throwable(message, exception) {
 
     /**
@@ -60,7 +60,7 @@ data class ConnectError constructor(
             message,
             exception,
             details,
-            metadata
+            metadata,
         )
     }
 }

--- a/library/src/main/kotlin/com/connectrpc/ConnectErrorDetail.kt
+++ b/library/src/main/kotlin/com/connectrpc/ConnectErrorDetail.kt
@@ -24,9 +24,9 @@ import okio.ByteString
 //
 // The [google.golang.org/genproto/googleapis/rpc/errdetails] package contains a
 // variety of Protobuf messages commonly used as error details.
-data class ConnectErrorDetail constructor(
+data class ConnectErrorDetail(
     val type: String,
-    val payload: ByteString
+    val payload: ByteString,
 ) {
     val pb = AnyError(type, payload)
 }

--- a/library/src/main/kotlin/com/connectrpc/Interceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/Interceptor.kt
@@ -49,11 +49,11 @@ interface Interceptor {
 
 class UnaryFunction(
     val requestFunction: (HTTPRequest) -> HTTPRequest = { it },
-    val responseFunction: (HTTPResponse) -> HTTPResponse = { it }
+    val responseFunction: (HTTPResponse) -> HTTPResponse = { it },
 )
 
 class StreamFunction(
     val requestFunction: (HTTPRequest) -> HTTPRequest = { it },
     val requestBodyFunction: (Buffer) -> Buffer = { it },
-    val streamResultFunction: (StreamResult<Buffer>) -> StreamResult<Buffer> = { it }
+    val streamResultFunction: (StreamResult<Buffer>) -> StreamResult<Buffer> = { it },
 )

--- a/library/src/main/kotlin/com/connectrpc/MethodSpec.kt
+++ b/library/src/main/kotlin/com/connectrpc/MethodSpec.kt
@@ -36,5 +36,5 @@ class MethodSpec<Input : Any, Output : Any>(
     val requestClass: KClass<Input>,
     val responseClass: KClass<Output>,
     val idempotency: Idempotency = Idempotency.UNKNOWN,
-    val method: String = Method.POST_METHOD
+    val method: String = Method.POST_METHOD,
 )

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -44,7 +44,7 @@ class ProtocolClientConfig @JvmOverloads constructor(
     interceptors: List<(ProtocolClientConfig) -> Interceptor> = emptyList(),
     // Compression pools that provide support for the provided `compressionName`, as well as any
     // other compression methods that need to be supported for inbound responses.
-    compressionPools: List<CompressionPool> = listOf(GzipCompressionPool)
+    compressionPools: List<CompressionPool> = listOf(GzipCompressionPool),
 ) {
     private val internalInterceptorFactoryList = mutableListOf<(ProtocolClientConfig) -> Interceptor>()
     private val compressionPools = mutableMapOf<String, CompressionPool>()
@@ -112,7 +112,7 @@ class ProtocolClientConfig @JvmOverloads constructor(
     }
 
     private fun chain(
-        interceptorFactories: List<(ProtocolClientConfig) -> Interceptor>
+        interceptorFactories: List<(ProtocolClientConfig) -> Interceptor>,
     ): Interceptor {
         val interceptors = interceptorFactories.map { factory -> factory(this) }
         return object : Interceptor {
@@ -132,7 +132,7 @@ class ProtocolClientConfig @JvmOverloads constructor(
                             response = unaryFunction.responseFunction(response)
                         }
                         response
-                    }
+                    },
                 )
             }
 
@@ -159,7 +159,7 @@ class ProtocolClientConfig @JvmOverloads constructor(
                             result = streamFunction.streamResultFunction(result)
                         }
                         result
-                    }
+                    },
                 )
             }
         }

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
@@ -38,7 +38,7 @@ interface ProtocolClientInterface {
         request: Input,
         headers: Headers,
         methodSpec: MethodSpec<Input, Output>,
-        onResult: (ResponseMessage<Output>) -> Unit
+        onResult: (ResponseMessage<Output>) -> Unit,
     ): Cancelable
 
     /**
@@ -53,7 +53,7 @@ interface ProtocolClientInterface {
     suspend fun <Input : Any, Output : Any> unary(
         request: Input,
         headers: Headers,
-        methodSpec: MethodSpec<Input, Output>
+        methodSpec: MethodSpec<Input, Output>,
     ): ResponseMessage<Output>
 
     /**
@@ -68,7 +68,7 @@ interface ProtocolClientInterface {
     fun <Input : Any, Output : Any> unaryBlocking(
         request: Input,
         headers: Headers,
-        methodSpec: MethodSpec<Input, Output>
+        methodSpec: MethodSpec<Input, Output>,
     ): UnaryBlockingCall<Output>
 
     /**
@@ -81,7 +81,7 @@ interface ProtocolClientInterface {
      */
     suspend fun <Input : Any, Output : Any> stream(
         headers: Headers,
-        methodSpec: MethodSpec<Input, Output>
+        methodSpec: MethodSpec<Input, Output>,
     ): BidirectionalStreamInterface<Input, Output>
 
     /**
@@ -94,7 +94,7 @@ interface ProtocolClientInterface {
      */
     suspend fun <Input : Any, Output : Any> serverStream(
         headers: Headers,
-        methodSpec: MethodSpec<Input, Output>
+        methodSpec: MethodSpec<Input, Output>,
     ): ServerOnlyStreamInterface<Input, Output>
 
     /**
@@ -107,6 +107,6 @@ interface ProtocolClientInterface {
      */
     suspend fun <Input : Any, Output : Any> clientStream(
         headers: Headers,
-        methodSpec: MethodSpec<Input, Output>
+        methodSpec: MethodSpec<Input, Output>,
     ): ClientOnlyStreamInterface<Input, Output>
 }

--- a/library/src/main/kotlin/com/connectrpc/RequestCompression.kt
+++ b/library/src/main/kotlin/com/connectrpc/RequestCompression.kt
@@ -24,7 +24,7 @@ data class RequestCompression(
     // The minimum number of bytes that a request message should be for compression to be used.
     val minBytes: Int,
     // The compression pool that should be used for compressing outbound requests.
-    val compressionPool: CompressionPool
+    val compressionPool: CompressionPool,
 ) {
     /**
      * Checks if the input buffer meets the compression requirements.

--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -23,7 +23,7 @@ sealed class ResponseMessage<Output>(
     // Response headers specified by the server.
     open val headers: Headers,
     // Trailers provided by the server.
-    open val trailers: Trailers
+    open val trailers: Trailers,
 ) {
     class Success<Output>(
         // The message.
@@ -33,7 +33,7 @@ sealed class ResponseMessage<Output>(
         // Response headers specified by the server.
         override val headers: Headers,
         // Trailers provided by the server.
-        override val trailers: Trailers
+        override val trailers: Trailers,
     ) : ResponseMessage<Output>(code, headers, trailers)
 
     class Failure<Output>(
@@ -44,7 +44,7 @@ sealed class ResponseMessage<Output>(
         // Response headers specified by the server.
         override val headers: Headers,
         // Trailers provided by the server.
-        override val trailers: Trailers
+        override val trailers: Trailers,
     ) : ResponseMessage<Output>(code, headers, trailers)
 
     fun <E> failure(function: (Failure<Output>) -> E?): E? {
@@ -81,7 +81,7 @@ fun ResponseMessage<*>.exceptionOrNull(): Throwable? {
  */
 inline fun <R, T> ResponseMessage<T>.fold(
     onSuccess: (value: T) -> R,
-    onFailure: (exception: Throwable) -> R
+    onFailure: (exception: Throwable) -> R,
 ): R {
     return when (this) {
         is ResponseMessage.Success -> onSuccess(this.message)

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -20,7 +20,7 @@ package com.connectrpc
  * A typical stream receives [Headers] > [Message] > [Message] > [Message] ... > [Complete]
  */
 sealed class StreamResult<Output>(
-    val error: Throwable? = null
+    val error: Throwable? = null,
 ) {
     // Headers have been received over the stream.
     class Headers<Output>(val headers: com.connectrpc.Headers) : StreamResult<Output>()
@@ -53,7 +53,7 @@ sealed class StreamResult<Output>(
     fun <Result> fold(
         onHeaders: (Headers<Output>) -> Result,
         onMessage: (Message<Output>) -> Result,
-        onCompletion: (Complete<Output>) -> Result
+        onCompletion: (Complete<Output>) -> Result,
     ): Result {
         return when (this) {
             is Headers -> {
@@ -78,7 +78,7 @@ sealed class StreamResult<Output>(
     fun <Result> maybeFold(
         onHeaders: (Headers<Output>) -> Result? = { null },
         onMessage: (Message<Output>) -> Result? = { null },
-        onCompletion: (Complete<Output>) -> Result? = { null }
+        onCompletion: (Complete<Output>) -> Result? = { null },
     ): Result? {
         return when (this) {
             is Headers -> {

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -50,7 +50,7 @@ interface HTTPClientInterface {
 class Stream(
     private val onSend: (Buffer) -> Unit,
     private val onSendClose: () -> Unit = {},
-    private val onReceiveClose: () -> Unit = {}
+    private val onReceiveClose: () -> Unit = {},
 ) {
     private val isSendClosed = AtomicReference(false)
     private val isReceiveClosed = AtomicReference(false)

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
@@ -31,7 +31,7 @@ class HTTPRequest internal constructor(
     // Body data to send with the request.
     val message: ByteArray? = null,
     // The method spec associated with the request.
-    val methodSpec: MethodSpec<*, *>
+    val methodSpec: MethodSpec<*, *>,
 ) {
     /**
      * Clones the [HTTPRequest] with override values.
@@ -49,14 +49,14 @@ class HTTPRequest internal constructor(
         // Body data to send with the request.
         message: ByteArray? = this.message,
         // The method spec associated with the request.
-        methodSpec: MethodSpec<*, *> = this.methodSpec
+        methodSpec: MethodSpec<*, *> = this.methodSpec,
     ): HTTPRequest {
         return HTTPRequest(
             url,
             contentType,
             headers,
             message,
-            methodSpec
+            methodSpec,
         )
     }
 }

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
@@ -38,5 +38,5 @@ class HTTPResponse(
     // null in cases where no response was received from the server.
     val tracingInfo: TracingInfo?,
     // The accompanying error, if the request failed.
-    val error: ConnectError? = null
+    val error: ConnectError? = null,
 )

--- a/library/src/main/kotlin/com/connectrpc/http/TracingInfo.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/TracingInfo.kt
@@ -19,5 +19,5 @@ package com.connectrpc.http
  */
 data class TracingInfo(
     // The underlying http status code
-    val httpStatus: Int
+    val httpStatus: Int,
 )

--- a/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
@@ -28,7 +28,7 @@ import java.lang.Exception
 internal class BidirectionalStream<Input, Output>(
     val stream: Stream,
     private val requestCodec: Codec<Input>,
-    private val receiveChannel: Channel<StreamResult<Output>>
+    private val receiveChannel: Channel<StreamResult<Output>>,
 ) : BidirectionalStreamInterface<Input, Output> {
 
     override suspend fun send(input: Input): Result<Unit> {

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -22,7 +22,7 @@ import com.connectrpc.StreamResult
  * Concrete implementation of [ClientOnlyStreamInterface].
  */
 internal class ClientOnlyStream<Input, Output>(
-    private val messageStream: BidirectionalStreamInterface<Input, Output>
+    private val messageStream: BidirectionalStreamInterface<Input, Output>,
 ) : ClientOnlyStreamInterface<Input, Output> {
     override suspend fun send(input: Input): Result<Unit> {
         return messageStream.send(input)

--- a/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
  * Concrete implementation of [ServerOnlyStreamInterface].
  */
 internal class ServerOnlyStream<Input, Output>(
-    private val messageStream: BidirectionalStreamInterface<Input, Output>
+    private val messageStream: BidirectionalStreamInterface<Input, Output>,
 ) : ServerOnlyStreamInterface<Input, Output> {
     override fun resultChannel(): ReceiveChannel<StreamResult<Output>> {
         return messageStream.resultChannel()

--- a/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
@@ -21,17 +21,17 @@ import com.squareup.moshi.JsonClass
 internal class ErrorPayloadJSON(
     @Json(name = "code") val code: String?,
     @Json(name = "message") val message: String?,
-    @Json(name = "details") val details: List<ErrorDetailPayloadJSON>?
+    @Json(name = "details") val details: List<ErrorDetailPayloadJSON>?,
 )
 
 @JsonClass(generateAdapter = true)
 internal class ErrorDetailPayloadJSON(
     @Json(name = "type") val type: String?,
-    @Json(name = "value") val value: String?
+    @Json(name = "value") val value: String?,
 )
 
 @JsonClass(generateAdapter = true)
 internal class EndStreamResponseJSON(
     @Json(name = "error") val error: ErrorPayloadJSON?,
-    @Json(name = "metadata") val metadata: Map<String, List<String>>?
+    @Json(name = "metadata") val metadata: Map<String, List<String>>?,
 )

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
@@ -34,7 +34,7 @@ internal data class GRPCCompletion(
     // List of error details.
     val errorDetails: List<ConnectErrorDetail>,
     // Set to either message headers (or trailers) where the gRPC status was found.
-    val metadata: Headers
+    val metadata: Headers,
 )
 
 internal fun grpcCompletionToConnectError(completion: GRPCCompletion?, serializationStrategy: SerializationStrategy, error: Throwable?): ConnectError? {
@@ -49,7 +49,7 @@ internal fun grpcCompletionToConnectError(completion: GRPCCompletion?, serializa
             message = completion?.message?.utf8(),
             exception = error,
             details = completion?.errorDetails ?: emptyList(),
-            metadata = completion?.metadata ?: emptyMap()
+            metadata = completion?.metadata ?: emptyMap(),
         )
     }
     // Successful call.

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletionParser.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletionParser.kt
@@ -25,7 +25,7 @@ import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.encodeUtf8
 
 class GRPCCompletionParser(
-    private val errorDetailParser: ErrorDetailParser
+    private val errorDetailParser: ErrorDetailParser,
 ) {
     /**
      * Parses the completion of a GRPC response from the Headers (for trailers-only responses) or Trailers.
@@ -51,7 +51,7 @@ class GRPCCompletionParser(
             status,
             message,
             details,
-            metadata
+            metadata,
         )
     }
 

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -34,7 +34,7 @@ internal const val TRAILERS_BIT = 0b10000000
  * https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
  */
 internal class GRPCWebInterceptor(
-    private val clientConfig: ProtocolClientConfig
+    private val clientConfig: ProtocolClientConfig,
 ) : Interceptor {
     private val serializationStrategy = clientConfig.serializationStrategy
     private val completionParser = GRPCCompletionParser(serializationStrategy.errorDetailParser())
@@ -60,7 +60,7 @@ internal class GRPCWebInterceptor(
                 val envelopedMessage = Envelope.pack(
                     requestMessage,
                     requestCompressionPool?.compressionPool,
-                    requestCompressionPool?.minBytes
+                    requestCompressionPool?.minBytes,
                 )
 
                 request.clone(
@@ -68,7 +68,7 @@ internal class GRPCWebInterceptor(
                     // The underlying content type is overridden here.
                     contentType = "application/grpc-web+${serializationStrategy.serializationName()}",
                     headers = requestHeaders.withGRPCRequestHeaders(),
-                    message = envelopedMessage.readByteArray()
+                    message = envelopedMessage.readByteArray(),
                 )
             },
             responseFunction = { response ->
@@ -80,7 +80,7 @@ internal class GRPCWebInterceptor(
                         message = Buffer(),
                         trailers = emptyMap(),
                         error = response.error,
-                        tracingInfo = response.tracingInfo
+                        tracingInfo = response.tracingInfo,
                     )
                 }
                 val compressionPool =
@@ -110,9 +110,9 @@ internal class GRPCWebInterceptor(
                             code = code,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = completion?.message?.utf8(),
-                            details = completion?.errorDetails ?: emptyList()
+                            details = completion?.errorDetails ?: emptyList(),
                         ),
-                        tracingInfo = response.tracingInfo
+                        tracingInfo = response.tracingInfo,
                     )
                 } else {
                     // Unpack the current message and trailers.
@@ -126,7 +126,7 @@ internal class GRPCWebInterceptor(
                     // currentMessage will contain remaining bytes unread by unpackWithHeaderByte.
                     val (headerByte, unpacked) = Envelope.unpackWithHeaderByte(
                         currentMessage,
-                        compressionPool
+                        compressionPool,
                     )
                     // Check if the current message contains only trailers.
                     val trailerBuffer = if (headerByte.and(TRAILERS_BIT) == TRAILERS_BIT) {
@@ -135,7 +135,7 @@ internal class GRPCWebInterceptor(
                         // The previous chunk is the message which means this is the trailers.
                         val (_, trailerBuffer) = Envelope.unpackWithHeaderByte(
                             responseBuffer,
-                            compressionPool
+                            compressionPool,
                         )
                         trailerBuffer
                     }
@@ -150,7 +150,7 @@ internal class GRPCWebInterceptor(
                             code = finalCode,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = errorMessage.utf8(),
-                            details = completionWithMessage.errorDetails
+                            details = completionWithMessage.errorDetails,
                         )
                     } else {
                         null
@@ -161,10 +161,10 @@ internal class GRPCWebInterceptor(
                         message = unpacked,
                         trailers = finalTrailers,
                         error = error,
-                        tracingInfo = response.tracingInfo
+                        tracingInfo = response.tracingInfo,
                     )
                 }
-            }
+            },
         )
     }
 
@@ -175,7 +175,7 @@ internal class GRPCWebInterceptor(
                     url = request.url,
                     contentType = "application/grpc-web+${serializationStrategy.serializationName()}",
                     headers = request.headers.withGRPCRequestHeaders(),
-                    message = request.message
+                    message = request.message,
                 )
             },
             requestBodyFunction = { buffer ->
@@ -193,7 +193,7 @@ internal class GRPCWebInterceptor(
                             return@fold StreamResult.Complete(
                                 code = completion.code,
                                 error = connectError,
-                                trailers = responseHeaders
+                                trailers = responseHeaders,
                             )
                         }
                         StreamResult.Headers(responseHeaders)
@@ -201,7 +201,7 @@ internal class GRPCWebInterceptor(
                     onMessage = { result ->
                         val (headerByte, unpackedMessage) = Envelope.unpackWithHeaderByte(
                             result.message,
-                            responseCompressionPool
+                            responseCompressionPool,
                         )
                         if (headerByte.and(TRAILERS_BIT) == TRAILERS_BIT) {
                             val streamTrailers = parseGrpcWebTrailer(unpackedMessage)
@@ -211,17 +211,17 @@ internal class GRPCWebInterceptor(
                             return@fold StreamResult.Complete(
                                 code = code,
                                 error = connectError,
-                                trailers = streamTrailers
+                                trailers = streamTrailers,
                             )
                         }
                         StreamResult.Message(unpackedMessage)
                     },
                     onCompletion = { result ->
                         result
-                    }
+                    },
                 )
                 streamResult
-            }
+            },
         )
     }
 

--- a/library/src/test/kotlin/com/connectrpc/ConnectErrorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/ConnectErrorTest.kt
@@ -27,16 +27,16 @@ class ConnectErrorTest {
     fun connectErrorParsing() {
         val errorDetail = ConnectErrorDetail(
             "type",
-            "value".encodeUtf8()
+            "value".encodeUtf8(),
         )
         whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
         val connectError = ConnectError(
             code = Code.UNKNOWN,
             details = listOf(
                 errorDetail,
-                errorDetail
+                errorDetail,
             ),
-            errorDetailParser = errorDetailParser
+            errorDetailParser = errorDetailParser,
         )
         val parsedResult = connectError.unpackedDetails(String::class)
         assertThat(parsedResult).contains("unpacked_value", "unpacked_value")
@@ -46,14 +46,14 @@ class ConnectErrorTest {
     fun completionParsingUnset() {
         val errorDetail = ConnectErrorDetail(
             "type",
-            "value".encodeUtf8()
+            "value".encodeUtf8(),
         )
         whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
         val connectError = ConnectError(
             code = Code.UNKNOWN,
             details = listOf(
-                errorDetail
-            )
+                errorDetail,
+            ),
         )
         val parsedResult = connectError.unpackedDetails(String::class)
         assertThat(parsedResult).isEmpty()

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -26,10 +26,10 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import java.net.URL
 
-private val methodSpec = MethodSpec(
+private val METHOD_SPEC = MethodSpec(
     path = "",
     requestClass = Any::class,
-    responseClass = Any::class
+    responseClass = Any::class,
 )
 
 class InterceptorChainTest {
@@ -50,13 +50,13 @@ class InterceptorChainTest {
             },
             { _: ProtocolClientConfig ->
                 SimpleInterceptor("4")
-            }
+            },
         )
         val protocolClientConfig = ProtocolClientConfig(
             host = "host",
             serializationStrategy = mock { },
             networkProtocol = NetworkProtocol.CONNECT,
-            interceptors = interceptorFactories
+            interceptors = interceptorFactories,
         )
         unaryChain = protocolClientConfig.createInterceptorChain()
         streamingChain = protocolClientConfig.createStreamingInterceptorChain()
@@ -64,7 +64,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_unary() {
-        val response = unaryChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, methodSpec))
+        val response = unaryChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, METHOD_SPEC))
         assertThat(response.headers.get("id")).containsExactly("1", "2", "3", "4")
     }
 
@@ -76,7 +76,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_stream() {
-        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, methodSpec))
+        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, METHOD_SPEC))
         assertThat(request.headers.get("id")).containsExactly("1", "2", "3", "4")
     }
 
@@ -112,7 +112,7 @@ class InterceptorChainTest {
                         it.contentType,
                         headers,
                         it.message,
-                        methodSpec
+                        METHOD_SPEC,
                     )
                 },
                 responseFunction = {
@@ -126,9 +126,9 @@ class InterceptorChainTest {
                         it.message,
                         it.trailers,
                         it.tracingInfo,
-                        it.error
+                        it.error,
                     )
-                }
+                },
             )
         }
 
@@ -144,7 +144,7 @@ class InterceptorChainTest {
                         it.contentType,
                         headers,
                         it.message,
-                        methodSpec
+                        METHOD_SPEC,
                     )
                 },
                 requestBodyFunction = {
@@ -160,9 +160,9 @@ class InterceptorChainTest {
                             StreamResult.Headers(headers)
                         },
                         onMessage = { it },
-                        onCompletion = { it }
+                        onCompletion = { it },
                     )
-                }
+                },
             )
         }
     }

--- a/library/src/test/kotlin/com/connectrpc/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/ProtocolClientConfigTest.kt
@@ -20,14 +20,13 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import java.net.MalformedURLException
 
-
 class ProtocolClientConfigTest {
 
     @Test
     fun hostUri() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = mock { }
+            serializationStrategy = mock { },
         )
         assertThat(config.baseUri.host).isEqualTo("connectrpc.com")
         assertThat(config.baseUri.toURL()).isNotNull()
@@ -37,7 +36,7 @@ class ProtocolClientConfigTest {
     fun unsupportedSchemeErrorsWhenTranslatingToURL() {
         val config = ProtocolClientConfig(
             host = "xhtp://connectrpc.com",
-            serializationStrategy = mock { }
+            serializationStrategy = mock { },
         )
         config.baseUri.toURL()
         fail<Unit>("expecting URL construction to fail")

--- a/library/src/test/kotlin/com/connectrpc/impl/BiDirectionalStreamTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/BiDirectionalStreamTest.kt
@@ -43,8 +43,8 @@ class BiDirectionalStreamTest {
             httpClient = mock { },
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com/",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
 
         CoroutineScope(Dispatchers.IO).launch {
@@ -53,8 +53,8 @@ class BiDirectionalStreamTest {
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,
-                    String::class
-                )
+                    String::class,
+                ),
             )
 
             stream.close()
@@ -73,8 +73,8 @@ class BiDirectionalStreamTest {
             httpClient = mock { },
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com/",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
 
         CoroutineScope(Dispatchers.IO).launch {
@@ -83,8 +83,8 @@ class BiDirectionalStreamTest {
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,
-                    String::class
-                )
+                    String::class,
+                ),
             )
 
             stream.close()

--- a/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
@@ -47,8 +47,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com/",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         client.unary(
             "input",
@@ -56,8 +56,8 @@ class ProtocolClientTest {
             MethodSpec(
                 path = "com.connectrpc.SomeService/Service",
                 String::class,
-                String::class
-            )
+                String::class,
+            ),
         ) { _ -> }
     }
 
@@ -71,8 +71,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         client.unary(
             "input",
@@ -80,8 +80,8 @@ class ProtocolClientTest {
             MethodSpec(
                 path = "com.connectrpc.SomeService/Service",
                 String::class,
-                String::class
-            )
+                String::class,
+            ),
         ) { _ -> }
     }
 
@@ -95,8 +95,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com/",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         CoroutineScope(Dispatchers.IO).launch {
             client.stream(
@@ -104,8 +104,8 @@ class ProtocolClientTest {
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,
-                    String::class
-                )
+                    String::class,
+                ),
             )
         }
     }
@@ -120,8 +120,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         CoroutineScope(Dispatchers.IO).launch {
             client.stream(
@@ -129,8 +129,8 @@ class ProtocolClientTest {
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,
-                    String::class
-                )
+                    String::class,
+                ),
             )
         }
     }
@@ -144,8 +144,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         client.unary(
             "",
@@ -153,8 +153,8 @@ class ProtocolClientTest {
             MethodSpec(
                 path = "com.connectrpc.SomeService/Service",
                 String::class,
-                String::class
-            )
+                String::class,
+            ),
         ) {}
 
         // Use HTTP client to determine and verify the final URL.
@@ -172,8 +172,8 @@ class ProtocolClientTest {
             httpClient = httpClient,
             config = ProtocolClientConfig(
                 host = "https://connectrpc.com/",
-                serializationStrategy = serializationStrategy
-            )
+                serializationStrategy = serializationStrategy,
+            ),
         )
         client.unary(
             "",
@@ -181,8 +181,8 @@ class ProtocolClientTest {
             MethodSpec(
                 path = "com.connectrpc.SomeService/Service",
                 String::class,
-                String::class
-            )
+                String::class,
+            ),
         ) {}
 
         // Use HTTP client to determine and verify the final URL.

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -65,7 +65,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = emptyList()
+            compressionPools = emptyList(),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -78,9 +78,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[CONNECT_PROTOCOL_VERSION_KEY]).containsExactly(CONNECT_PROTOCOL_VERSION_VALUE)
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
@@ -95,7 +95,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://buf.build",
             serializationStrategy = serializationStrategy,
-            compressionPools = emptyList()
+            compressionPools = emptyList(),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -108,9 +108,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[USER_AGENT]).isNull()
@@ -121,7 +121,7 @@ class ConnectInterceptorTest {
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -135,9 +135,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.message!!.commonToUtf8String()).isEqualTo("message")
     }
@@ -148,7 +148,7 @@ class ConnectInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -162,9 +162,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         val decompressed = GzipCompressionPool.decompress(Buffer().write(request.message!!))
         assertThat(decompressed.readUtf8()).isEqualTo("message")
@@ -175,7 +175,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -186,8 +186,8 @@ class ConnectInterceptorTest {
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -197,7 +197,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -208,8 +208,8 @@ class ConnectInterceptorTest {
                 headers = mapOf(CONTENT_ENCODING to listOf(GzipCompressionPool.name())),
                 message = GzipCompressionPool.compress(Buffer().write("message".encodeUtf8())),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -219,7 +219,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -229,9 +229,9 @@ class ConnectInterceptorTest {
             listOf(
                 ErrorDetailPayloadJSON(
                     "type",
-                    "value"
-                )
-            )
+                    "value",
+                ),
+            ),
         )
         val adapter = moshi.adapter(ErrorPayloadJSON::class.java)
         val json = adapter.toJson(error)
@@ -242,8 +242,8 @@ class ConnectInterceptorTest {
                 message = Buffer().write(json.encodeUtf8()),
                 headers = emptyMap(),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
         assertThat(response.error!!.message).isEqualTo("no more resources!")
@@ -257,7 +257,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -268,8 +268,8 @@ class ConnectInterceptorTest {
                 message = Buffer().write("garbage json".encodeUtf8()),
                 headers = emptyMap(),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.error!!.code).isEqualTo(Code.UNAVAILABLE)
     }
@@ -278,7 +278,7 @@ class ConnectInterceptorTest {
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = ConnectInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -289,8 +289,8 @@ class ConnectInterceptorTest {
                 emptyMap(),
                 Buffer(),
                 emptyMap(),
-                TracingInfo(888)
-            )
+                TracingInfo(888),
+            ),
         )
         assertThat(result.tracingInfo!!.httpStatus).isEqualTo(888)
     }
@@ -304,7 +304,7 @@ class ConnectInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -317,9 +317,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[CONNECT_PROTOCOL_VERSION_KEY]).containsExactly(CONNECT_PROTOCOL_VERSION_VALUE)
         assertThat(request.headers[CONNECT_STREAMING_ACCEPT_ENCODING]).containsExactly(GzipCompressionPool.name())
@@ -335,7 +335,7 @@ class ConnectInterceptorTest {
             host = "https://buf.build",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -348,9 +348,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[USER_AGENT]).isNull()
@@ -362,7 +362,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = emptyList()
+            compressionPools = emptyList(),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -375,9 +375,9 @@ class ConnectInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[CONNECT_PROTOCOL_VERSION_KEY]).containsExactly(CONNECT_PROTOCOL_VERSION_VALUE)
         assertThat(request.headers[CONNECT_STREAMING_ACCEPT_ENCODING]).isNullOrEmpty()
@@ -391,7 +391,7 @@ class ConnectInterceptorTest {
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -406,7 +406,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -421,7 +421,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -430,9 +430,9 @@ class ConnectInterceptorTest {
             StreamResult.Headers(
                 headers = mapOf(
                     "trailer-x-some-key" to listOf("some_value"),
-                    CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip")
-                )
-            )
+                    CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Headers::class.java)
@@ -445,7 +445,7 @@ class ConnectInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -455,8 +455,8 @@ class ConnectInterceptorTest {
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()))
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write(envelopedMessage.readByteString())
-            )
+                Buffer().write(envelopedMessage.readByteString()),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -470,7 +470,7 @@ class ConnectInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -478,16 +478,16 @@ class ConnectInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
-                    CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip")
-                )
-            )
+                    CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
+                ),
+            ),
         )
 
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()), GzipCompressionPool, 1)
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write(envelopedMessage.readByteString())
-            )
+                Buffer().write(envelopedMessage.readByteString()),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -499,7 +499,7 @@ class ConnectInterceptorTest {
     fun endStreamOnResponseMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -509,13 +509,13 @@ class ConnectInterceptorTest {
             listOf(
                 ErrorDetailPayloadJSON(
                     "type",
-                    "value"
-                )
-            )
+                    "value",
+                ),
+            ),
         )
         val endStream = EndStreamResponseJSON(
             error = error,
-            metadata = emptyMap()
+            metadata = emptyMap(),
         )
         val adapter = moshi.adapter(EndStreamResponseJSON::class.java)
         val json = adapter.toJson(endStream)
@@ -527,8 +527,8 @@ class ConnectInterceptorTest {
 
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write(endStreamMessage.readByteString())
-            )
+                Buffer().write(endStreamMessage.readByteString()),
+            ),
         )
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
@@ -544,15 +544,15 @@ class ConnectInterceptorTest {
     fun endStreamResponseBadJSON() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
 
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write("some garbage json".encodeUtf8())
-            )
+                Buffer().write("some garbage json".encodeUtf8()),
+            ),
         )
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
@@ -563,7 +563,7 @@ class ConnectInterceptorTest {
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -572,9 +572,9 @@ class ConnectInterceptorTest {
             StreamResult.Complete(
                 code = Code.OK,
                 trailers = mapOf(
-                    "key" to listOf("value")
-                )
-            )
+                    "key" to listOf("value"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
@@ -587,7 +587,7 @@ class ConnectInterceptorTest {
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val streamFunction = connectInterceptor.streamFunction()
@@ -597,9 +597,9 @@ class ConnectInterceptorTest {
                 code = Code.UNKNOWN,
                 error = ConnectError(
                     Code.UNKNOWN,
-                    message = "error_message"
-                )
-            )
+                    message = "error_message",
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
@@ -614,8 +614,8 @@ class ConnectInterceptorTest {
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.EnabledWithFallback(
-                maxMessageBytes = 10_000
-            )
+                maxMessageBytes = 10_000,
+            ),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -630,9 +630,9 @@ class ConnectInterceptorTest {
                     path = "",
                     requestClass = Any::class,
                     responseClass = Any::class,
-                    idempotency = Idempotency.NO_SIDE_EFFECTS
-                )
-            )
+                    idempotency = Idempotency.NO_SIDE_EFFECTS,
+                ),
+            ),
         )
 
         val queryMap = parseQuery(request)
@@ -650,8 +650,8 @@ class ConnectInterceptorTest {
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.EnabledWithFallback(
-                maxMessageBytes = 1
-            )
+                maxMessageBytes = 1,
+            ),
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -666,9 +666,9 @@ class ConnectInterceptorTest {
                     path = "",
                     requestClass = Any::class,
                     responseClass = Any::class,
-                    idempotency = Idempotency.NO_SIDE_EFFECTS
-                )
-            )
+                    idempotency = Idempotency.NO_SIDE_EFFECTS,
+                ),
+            ),
         )
         assertThat(request.url.query).isNull()
         assertThat(request.methodSpec.method).isEqualTo(POST_METHOD)
@@ -680,7 +680,7 @@ class ConnectInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
-            getConfiguration = GETConfiguration.Enabled
+            getConfiguration = GETConfiguration.Enabled,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -694,9 +694,9 @@ class ConnectInterceptorTest {
                     path = "",
                     requestClass = Any::class,
                     responseClass = Any::class,
-                    idempotency = Idempotency.NO_SIDE_EFFECTS
-                )
-            )
+                    idempotency = Idempotency.NO_SIDE_EFFECTS,
+                ),
+            ),
         )
         val queryMap = parseQuery(request)
         assertThat(queryMap.get(GETConstants.MESSAGE_QUERY_PARAM_KEY)).isNotNull()
@@ -712,7 +712,7 @@ class ConnectInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
-            getConfiguration = GETConfiguration.Disabled
+            getConfiguration = GETConfiguration.Disabled,
         )
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
@@ -727,9 +727,9 @@ class ConnectInterceptorTest {
                     path = "",
                     requestClass = Any::class,
                     responseClass = Any::class,
-                    idempotency = Idempotency.NO_SIDE_EFFECTS
-                )
-            )
+                    idempotency = Idempotency.NO_SIDE_EFFECTS,
+                ),
+            ),
         )
         assertThat(request.url.query).isNull()
         assertThat(request.methodSpec.method).isEqualTo(POST_METHOD)

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCErrorDetailParserTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCErrorDetailParserTest.kt
@@ -35,8 +35,8 @@ class GRPCErrorDetailParserTest {
             trailers = mapOf(
                 GRPC_STATUS_TRAILER to listOf("${Code.UNAUTHENTICATED.value}"),
                 GRPC_MESSAGE_TRAILER to listOf("str"),
-                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64())
-            )
+                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64()),
+            ),
         )
         assertThat(completion!!.code).isEqualTo(Code.UNAUTHENTICATED)
         assertThat(completion.message.utf8()).isEqualTo("str")
@@ -50,8 +50,8 @@ class GRPCErrorDetailParserTest {
             headers = emptyMap(),
             trailers = mapOf(
                 GRPC_MESSAGE_TRAILER to listOf("str"),
-                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64())
-            )
+                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64()),
+            ),
         )
         assertThat(completion).isNull()
     }
@@ -62,9 +62,9 @@ class GRPCErrorDetailParserTest {
         val completion = parser.parse(
             headers = mapOf(
                 GRPC_STATUS_TRAILER to listOf("${Code.UNAUTHENTICATED.value}"),
-                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64())
+                GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64()),
             ),
-            trailers = emptyMap()
+            trailers = emptyMap(),
         )
         assertThat(completion!!.code).isEqualTo(Code.UNAUTHENTICATED)
     }
@@ -76,8 +76,8 @@ class GRPCErrorDetailParserTest {
             headers = emptyMap(),
             trailers = mapOf(
                 GRPC_STATUS_TRAILER to listOf("${Code.UNAUTHENTICATED.value}"),
-                GRPC_MESSAGE_TRAILER to listOf("str")
-            )
+                GRPC_MESSAGE_TRAILER to listOf("str"),
+            ),
         )
         assertThat(completion!!.errorDetails).isEmpty()
     }

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -58,7 +58,7 @@ class GRPCInterceptorTest {
     fun requestHeaders() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -71,9 +71,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
         assertThat(request.headers[CONTENT_ENCODING]).isNullOrEmpty()
@@ -85,7 +85,7 @@ class GRPCInterceptorTest {
     fun requestHeadersCustomUserAgent() {
         val config = ProtocolClientConfig(
             host = "https://buf.build",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -98,9 +98,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[USER_AGENT]).isNull()
@@ -111,7 +111,7 @@ class GRPCInterceptorTest {
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -125,9 +125,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
         assertThat(message.readUtf8()).isEqualTo("message")
@@ -139,7 +139,7 @@ class GRPCInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -153,9 +153,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
         val decompressed = GzipCompressionPool.decompress(message)
@@ -167,7 +167,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
 
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -182,10 +182,10 @@ class GRPCInterceptorTest {
                 headers = emptyMap(),
                 message = envelopedMessage,
                 trailers = mapOf(
-                    GRPC_STATUS_TRAILER to listOf("${Code.OK.value}")
+                    GRPC_STATUS_TRAILER to listOf("${Code.OK.value}"),
                 ),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -195,7 +195,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -207,10 +207,10 @@ class GRPCInterceptorTest {
                 headers = mapOf(GRPC_ENCODING to listOf(GzipCompressionPool.name())),
                 message = envelopedMessage,
                 trailers = mapOf(
-                    GRPC_STATUS_TRAILER to listOf("${Code.OK.value}")
+                    GRPC_STATUS_TRAILER to listOf("${Code.OK.value}"),
                 ),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -222,14 +222,14 @@ class GRPCInterceptorTest {
             listOf(
                 ConnectErrorDetail(
                     "type",
-                    "value".encodeUtf8()
-                )
-            )
+                    "value".encodeUtf8(),
+                ),
+            ),
         )
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcInterceptor.unaryFunction()
@@ -239,9 +239,9 @@ class GRPCInterceptorTest {
             listOf(
                 ErrorDetailPayloadJSON(
                     "type",
-                    "value"
-                )
-            )
+                    "value",
+                ),
+            ),
         )
         val adapter = moshi.adapter(ErrorPayloadJSON::class.java)
         val json = adapter.toJson(error)
@@ -254,10 +254,10 @@ class GRPCInterceptorTest {
                 trailers = mapOf(
                     GRPC_STATUS_TRAILER to listOf("${Code.RESOURCE_EXHAUSTED.value}"),
                     GRPC_MESSAGE_TRAILER to listOf("no more resources!"),
-                    GRPC_STATUS_DETAILS_TRAILERS to listOf(statusDetails)
+                    GRPC_STATUS_DETAILS_TRAILERS to listOf(statusDetails),
                 ),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
         assertThat(response.error!!.message).isEqualTo("no more resources!")
@@ -270,7 +270,7 @@ class GRPCInterceptorTest {
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -281,8 +281,8 @@ class GRPCInterceptorTest {
                 emptyMap(),
                 Buffer(),
                 emptyMap(),
-                TracingInfo(888)
-            )
+                TracingInfo(888),
+            ),
         )
         assertThat(result.tracingInfo!!.httpStatus).isEqualTo(888)
     }
@@ -296,7 +296,7 @@ class GRPCInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -307,14 +307,14 @@ class GRPCInterceptorTest {
                 contentType = "",
                 headers = mapOf(
                     // Doesn't get passed as headers.
-                    GRPC_ENCODING to listOf("gzip")
+                    GRPC_ENCODING to listOf("gzip"),
                 ),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.contentType).isEqualTo("application/grpc+${serializationStrategy.serializationName()}")
         assertThat(request.headers[USER_AGENT]).containsExactly("grpc-kotlin-connect/dev")
@@ -328,7 +328,7 @@ class GRPCInterceptorTest {
             host = "https://buf.build",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -341,9 +341,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[USER_AGENT]).isNull()
@@ -354,7 +354,7 @@ class GRPCInterceptorTest {
     fun streamingRequestHeadersWithoutAnyCompression() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -367,9 +367,9 @@ class GRPCInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.contentType).isEqualTo("application/grpc+${serializationStrategy.serializationName()}")
         assertThat(request.headers[USER_AGENT]).containsExactly("grpc-kotlin-connect/dev")
@@ -380,7 +380,7 @@ class GRPCInterceptorTest {
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -395,7 +395,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -410,7 +410,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -418,9 +418,9 @@ class GRPCInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Headers(
                 mapOf(
-                    "key" to listOf("value")
-                )
-            )
+                    "key" to listOf("value"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Headers::class.java)
@@ -433,7 +433,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -443,8 +443,8 @@ class GRPCInterceptorTest {
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()))
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write(envelopedMessage.readByteString())
-            )
+                Buffer().write(envelopedMessage.readByteString()),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -457,7 +457,7 @@ class GRPCInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -465,16 +465,16 @@ class GRPCInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
-                    GRPC_ENCODING to listOf(GzipCompressionPool.name())
-                )
-            )
+                    GRPC_ENCODING to listOf(GzipCompressionPool.name()),
+                ),
+            ),
         )
 
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()), GzipCompressionPool, 1)
         val result = streamFunction.streamResultFunction(
             StreamResult.Message(
-                Buffer().write(envelopedMessage.readByteString())
-            )
+                Buffer().write(envelopedMessage.readByteString()),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -486,7 +486,7 @@ class GRPCInterceptorTest {
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -496,9 +496,9 @@ class GRPCInterceptorTest {
                 code = Code.OK,
                 trailers = mapOf(
                     GRPC_STATUS_TRAILER to listOf("${Code.OK.value}"),
-                    "key" to listOf("value")
-                )
-            )
+                    "key" to listOf("value"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
@@ -511,7 +511,7 @@ class GRPCInterceptorTest {
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcInterceptor = GRPCInterceptor(config)
         val streamFunction = grpcInterceptor.streamFunction()
@@ -521,9 +521,9 @@ class GRPCInterceptorTest {
                 code = Code.UNKNOWN,
                 error = ConnectError(
                     Code.UNKNOWN,
-                    message = "error_message"
-                )
-            )
+                    message = "error_message",
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -54,7 +54,7 @@ class GRPCWebInterceptorTest {
     fun requestHeaders() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -67,9 +67,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
         assertThat(request.headers[CONTENT_ENCODING]).isNullOrEmpty()
@@ -82,7 +82,7 @@ class GRPCWebInterceptorTest {
     fun requestHeadersCustomUserAgent() {
         val config = ProtocolClientConfig(
             host = "https://buf.build",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -95,9 +95,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[GRPC_WEB_USER_AGENT]).isNull()
@@ -108,7 +108,7 @@ class GRPCWebInterceptorTest {
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -122,9 +122,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
         assertThat(message.readUtf8()).isEqualTo("message")
@@ -136,7 +136,7 @@ class GRPCWebInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -150,9 +150,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         val (_, decompressed) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!), GzipCompressionPool)
         assertThat(decompressed.readUtf8()).isEqualTo("message")
@@ -163,7 +163,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -175,8 +175,8 @@ class GRPCWebInterceptorTest {
                 headers = emptyMap(),
                 message = envelopedMessage,
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -186,7 +186,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -198,8 +198,8 @@ class GRPCWebInterceptorTest {
                 headers = mapOf(GRPC_ENCODING to listOf(GzipCompressionPool.name())),
                 message = envelopedMessage,
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.message.readUtf8()).isEqualTo("message")
     }
@@ -209,7 +209,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -218,12 +218,12 @@ class GRPCWebInterceptorTest {
             HTTPResponse(
                 code = Code.OK,
                 headers = mapOf(
-                    GRPC_STATUS_TRAILER to listOf("${Code.RESOURCE_EXHAUSTED.value}")
+                    GRPC_STATUS_TRAILER to listOf("${Code.RESOURCE_EXHAUSTED.value}"),
                 ),
                 message = Buffer(),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
     }
@@ -233,7 +233,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -249,8 +249,8 @@ class GRPCWebInterceptorTest {
                 message = trailers,
                 headers = emptyMap(),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
     }
@@ -260,7 +260,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -281,8 +281,8 @@ class GRPCWebInterceptorTest {
                 message = responseBody,
                 headers = emptyMap(),
                 trailers = emptyMap(),
-                tracingInfo = null
-            )
+                tracingInfo = null,
+            ),
         )
         assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
     }
@@ -291,7 +291,7 @@ class GRPCWebInterceptorTest {
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
@@ -302,8 +302,8 @@ class GRPCWebInterceptorTest {
                 emptyMap(),
                 Buffer(),
                 emptyMap(),
-                TracingInfo(888)
-            )
+                TracingInfo(888),
+            ),
         )
         assertThat(result.tracingInfo!!.httpStatus).isEqualTo(888)
     }
@@ -317,7 +317,7 @@ class GRPCWebInterceptorTest {
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -330,9 +330,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.contentType).isEqualTo("application/grpc-web+${serializationStrategy.serializationName()}")
         assertThat(request.headers.keys).containsExactlyInAnyOrder(GRPC_WEB_USER_AGENT, GRPC_ENCODING, "key")
@@ -347,7 +347,7 @@ class GRPCWebInterceptorTest {
             host = "https://buf.build",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -360,9 +360,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         // this will only work if we do a case-insensitive lookup of headers
         assertThat(request.headers[GRPC_WEB_USER_AGENT]).isNull()
@@ -373,7 +373,7 @@ class GRPCWebInterceptorTest {
     fun streamingRequestHeadersNoCompression() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -386,9 +386,9 @@ class GRPCWebInterceptorTest {
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
-                    responseClass = Any::class
-                )
-            )
+                    responseClass = Any::class,
+                ),
+            ),
         )
         assertThat(request.headers[GRPC_ENCODING]).isNullOrEmpty()
         assertThat(request.headers["key"]).containsExactly("value")
@@ -398,7 +398,7 @@ class GRPCWebInterceptorTest {
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -413,7 +413,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -428,7 +428,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -438,9 +438,9 @@ class GRPCWebInterceptorTest {
                 headers = mapOf(
                     // Doesn't get passed as headers.
                     "trailer-x-some-key" to listOf("some_value"),
-                    GRPC_ENCODING to listOf("gzip")
-                )
-            )
+                    GRPC_ENCODING to listOf("gzip"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Headers::class.java)
@@ -454,7 +454,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -463,7 +463,7 @@ class GRPCWebInterceptorTest {
 
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()))
         val result = streamFunction.streamResultFunction(
-            StreamResult.Message(envelopedMessage)
+            StreamResult.Message(envelopedMessage),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -476,7 +476,7 @@ class GRPCWebInterceptorTest {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
-            compressionPools = listOf(GzipCompressionPool)
+            compressionPools = listOf(GzipCompressionPool),
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -484,14 +484,14 @@ class GRPCWebInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
-                    GRPC_ENCODING to listOf("gzip")
-                )
-            )
+                    GRPC_ENCODING to listOf("gzip"),
+                ),
+            ),
         )
 
         val envelopedMessage = Envelope.pack(Buffer().write("hello".encodeUtf8()), GzipCompressionPool, 1)
         val result = streamFunction.streamResultFunction(
-            StreamResult.Message(envelopedMessage)
+            StreamResult.Message(envelopedMessage),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Message::class.java)
@@ -503,7 +503,7 @@ class GRPCWebInterceptorTest {
     fun endStreamOnResponseMessage() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -515,7 +515,7 @@ class GRPCWebInterceptorTest {
             .write(trailersPayload)
 
         val result = streamFunction.streamResultFunction(
-            StreamResult.Message(trailers)
+            StreamResult.Message(trailers),
         )
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
@@ -528,7 +528,7 @@ class GRPCWebInterceptorTest {
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -537,9 +537,9 @@ class GRPCWebInterceptorTest {
             StreamResult.Complete(
                 code = Code.OK,
                 trailers = mapOf(
-                    "key" to listOf("value")
-                )
-            )
+                    "key" to listOf("value"),
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
@@ -552,7 +552,7 @@ class GRPCWebInterceptorTest {
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
-            serializationStrategy = serializationStrategy
+            serializationStrategy = serializationStrategy,
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val streamFunction = grpcWebInterceptor.streamFunction()
@@ -562,9 +562,9 @@ class GRPCWebInterceptorTest {
                 code = Code.UNKNOWN,
                 error = ConnectError(
                     Code.UNKNOWN,
-                    message = "error_message"
-                )
-            )
+                    message = "error_message",
+                ),
+            ),
         )
 
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
     )
 }
 

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -38,7 +38,7 @@ import java.io.IOException
  * The OkHttp implementation of HTTPClientInterface.
  */
 class ConnectOkHttpClient @JvmOverloads constructor(
-    val client: OkHttpClient = OkHttpClient()
+    val client: OkHttpClient = OkHttpClient(),
 ) : HTTPClientInterface {
 
     override fun unary(request: HTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable {
@@ -77,10 +77,10 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                                 error = ConnectError(
                                     code,
                                     message = e.message,
-                                    exception = e
+                                    exception = e,
                                 ),
-                                tracingInfo = null
-                            )
+                                tracingInfo = null,
+                            ),
                         )
                     }
 
@@ -97,11 +97,11 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                                 headers = response.headers.toLowerCaseKeysMultiMap(),
                                 message = responseBuffer ?: Buffer(),
                                 trailers = response.trailers().toLowerCaseKeysMultiMap(),
-                                tracingInfo = TracingInfo(response.code)
-                            )
+                                tracingInfo = TracingInfo(response.code),
+                            ),
                         )
                     }
-                }
+                },
             )
         } catch (e: Throwable) {
             onResult(
@@ -113,10 +113,10 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                     error = ConnectError(
                         Code.UNKNOWN,
                         message = e.message,
-                        exception = e
+                        exception = e,
                     ),
-                    tracingInfo = null
-                )
+                    tracingInfo = null,
+                ),
             )
         }
         return cancelable
@@ -124,7 +124,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
 
     override fun stream(
         request: HTTPRequest,
-        onResult: suspend (StreamResult<Buffer>) -> Unit
+        onResult: suspend (StreamResult<Buffer>) -> Unit,
     ): Stream {
         return client.initializeStream(request.methodSpec.method, request, onResult)
     }

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal fun OkHttpClient.initializeStream(
     method: String,
     request: HTTPRequest,
-    onResult: suspend (StreamResult<Buffer>) -> Unit
+    onResult: suspend (StreamResult<Buffer>) -> Unit,
 ): Stream {
     val isSendClosed = AtomicBoolean(false)
     val isReceiveClosed = AtomicBoolean(false)
@@ -71,7 +71,7 @@ internal fun OkHttpClient.initializeStream(
         onSendClose = {
             isSendClosed.set(true)
             duplexRequestBody.close()
-        }
+        },
     ) {
         isReceiveClosed.set(true)
         call.cancel()
@@ -80,7 +80,7 @@ internal fun OkHttpClient.initializeStream(
 
 private class ResponseCallback(
     private val onResult: suspend (StreamResult<Buffer>) -> Unit,
-    private val isClosed: AtomicBoolean
+    private val isClosed: AtomicBoolean,
 ) : Callback {
     override fun onFailure(call: Call, e: IOException) {
         runBlocking {
@@ -105,7 +105,7 @@ private class ResponseCallback(
                 val finalResult = StreamResult.Complete<Buffer>(
                     code = code,
                     trailers = response.safeTrailers() ?: emptyMap(),
-                    error = ConnectError(code = code)
+                    error = ConnectError(code = code),
                 )
                 onResult(finalResult)
                 return@runBlocking
@@ -117,7 +117,7 @@ private class ResponseCallback(
                         while (!sourceBuffer.safeExhausted() && !isClosed.get()) {
                             val buffer = readStream(sourceBuffer)
                             val streamResult = StreamResult.Message(
-                                message = buffer
+                                message = buffer,
                             )
                             onResult(streamResult)
                         }
@@ -129,7 +129,7 @@ private class ResponseCallback(
                         val finalResult = StreamResult.Complete<Buffer>(
                             code = code,
                             trailers = response.safeTrailers() ?: emptyMap(),
-                            error = exception
+                            error = exception,
                         )
                         onResult(finalResult)
                     }
@@ -182,7 +182,7 @@ private class ResponseCallback(
 
 internal class PipeDuplexRequestBody(
     private val contentType: MediaType?,
-    pipeMaxBufferSize: Long = 1024 * 1024
+    pipeMaxBufferSize: Long = 1024 * 1024,
 ) : RequestBody() {
     private val pipe = Pipe(pipeMaxBufferSize)
 

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -47,7 +47,7 @@ sourceSets {
 
 configure<MavenPublishBaseExtension> {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
     )
 }
 

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/Generator.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/Generator.kt
@@ -68,7 +68,7 @@ class Generator : CodeGenerator {
     override fun generate(
         request: PluginProtos.CodeGeneratorRequest,
         descriptorSource: Plugin.DescriptorSource,
-        response: Plugin.Response
+        response: Plugin.Response,
     ) {
         this.descriptorSource = descriptorSource
         configuration = parse(request.parameter)
@@ -99,7 +99,7 @@ class Generator : CodeGenerator {
         val packageName = getFileJavaPackage(file)
         for ((sourceInfo, service) in file.services.withSourceInfo(
             baseSourceInfo,
-            FileDescriptorProto.SERVICE_FIELD_NUMBER
+            FileDescriptorProto.SERVICE_FIELD_NUMBER,
         )) {
             val interfaceFileSpec = FileSpec.builder(packageName, file.name)
                 // Manually import `method()` since it is a method and not a class.
@@ -133,7 +133,7 @@ class Generator : CodeGenerator {
     private fun serviceClientInterface(
         packageName: String,
         service: Descriptors.ServiceDescriptor,
-        sourceInfo: SourceInfo
+        sourceInfo: SourceInfo,
     ): TypeSpec {
         val interfaceBuilder = TypeSpec.interfaceBuilder(serviceClientInterfaceClassName(packageName, service))
         val functionSpecs = interfaceMethods(service.methods, sourceInfo)
@@ -145,7 +145,7 @@ class Generator : CodeGenerator {
 
     private fun interfaceMethods(
         methods: List<Descriptors.MethodDescriptor>,
-        baseSourceInfo: SourceInfo
+        baseSourceInfo: SourceInfo,
     ): List<FunSpec> {
         val functions = mutableListOf<FunSpec>()
         val headerParameterSpec = ParameterSpec.builder("headers", HEADERS_CLASS_NAME)
@@ -153,7 +153,7 @@ class Generator : CodeGenerator {
             .build()
         for ((sourceInfo, method) in methods.withSourceInfo(
             baseSourceInfo,
-            DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER
+            DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER,
         )) {
             val inputClassName = classNameFromType(method.inputType)
             val outputClassName = classNameFromType(method.outputType)
@@ -165,7 +165,7 @@ class Generator : CodeGenerator {
                     .addParameter(headerParameterSpec)
                     .returns(
                         BidirectionalStreamInterface::class.asClassName()
-                            .parameterizedBy(inputClassName, outputClassName)
+                            .parameterizedBy(inputClassName, outputClassName),
                     )
                 functions.add(streamingBuilder.build())
             } else if (method.isServerStreaming) {
@@ -175,7 +175,7 @@ class Generator : CodeGenerator {
                     .addModifiers(KModifier.SUSPEND)
                     .addParameter(headerParameterSpec)
                     .returns(
-                        ServerOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName)
+                        ServerOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName),
                     )
                     .build()
                 functions.add(serverStreamingFunction)
@@ -186,7 +186,7 @@ class Generator : CodeGenerator {
                     .addModifiers(KModifier.SUSPEND)
                     .addParameter(headerParameterSpec)
                     .returns(
-                        ClientOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName)
+                        ClientOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName),
                     )
                     .build()
                 functions.add(clientStreamingFunction)
@@ -207,10 +207,10 @@ class Generator : CodeGenerator {
                         parameters = listOf(
                             ParameterSpec(
                                 "",
-                                ResponseMessage::class.asTypeName().parameterizedBy(outputClassName)
-                            )
+                                ResponseMessage::class.asTypeName().parameterizedBy(outputClassName),
+                            ),
                         ),
-                        returnType = Unit::class.java.asTypeName()
+                        returnType = Unit::class.java.asTypeName(),
                     )
                     val unaryCallbackFunction = FunSpec.builder(method.name.lowerCamelCase())
                         .addKdoc(sourceInfo.comment().sanitizeKdoc())
@@ -240,7 +240,7 @@ class Generator : CodeGenerator {
     private fun serviceClientImplementation(
         javaPackageName: String,
         service: Descriptors.ServiceDescriptor,
-        sourceInfo: SourceInfo
+        sourceInfo: SourceInfo,
     ): TypeSpec {
         // The javaPackageName is used instead of the package name for imports and code references.
         val classBuilder = TypeSpec.classBuilder(serviceClientImplementationClassName(javaPackageName, service))
@@ -248,12 +248,12 @@ class Generator : CodeGenerator {
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("client", ProtocolClientInterface::class)
-                    .build()
+                    .build(),
             )
             .addProperty(
                 PropertySpec.builder("client", ProtocolClientInterface::class, KModifier.PRIVATE)
                     .initializer("client")
-                    .build()
+                    .build(),
             )
         val functionSpecs = implementationMethods(service.methods, sourceInfo)
         return classBuilder
@@ -264,12 +264,12 @@ class Generator : CodeGenerator {
 
     private fun implementationMethods(
         methods: List<Descriptors.MethodDescriptor>,
-        baseSourceInfo: SourceInfo
+        baseSourceInfo: SourceInfo,
     ): List<FunSpec> {
         val functions = mutableListOf<FunSpec>()
         for ((sourceInfo, method) in methods.withSourceInfo(
             baseSourceInfo,
-            DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER
+            DescriptorProtos.ServiceDescriptorProto.METHOD_FIELD_NUMBER,
         )) {
             val inputClassName = classNameFromType(method.inputType)
             val outputClassName = classNameFromType(method.outputType)
@@ -298,8 +298,8 @@ class Generator : CodeGenerator {
                         BidirectionalStreamInterface::class.asClassName()
                             .parameterizedBy(
                                 inputClassName,
-                                outputClassName
-                            )
+                                outputClassName,
+                            ),
                     )
                     .addStatement(
                         "return %L",
@@ -310,7 +310,7 @@ class Generator : CodeGenerator {
                             .add(methodSpecCallBlock)
                             .unindent()
                             .addStatement(")")
-                            .build()
+                            .build(),
                     )
                     .build()
                 functions.add(streamingFunction)
@@ -321,7 +321,7 @@ class Generator : CodeGenerator {
                     .addModifiers(KModifier.SUSPEND)
                     .addParameter("headers", HEADERS_CLASS_NAME)
                     .returns(
-                        ServerOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName)
+                        ServerOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName),
                     )
                     .addStatement(
                         "return %L",
@@ -332,7 +332,7 @@ class Generator : CodeGenerator {
                             .add(methodSpecCallBlock)
                             .unindent()
                             .addStatement(")")
-                            .build()
+                            .build(),
                     )
                     .build()
                 functions.add(serverStreamingFunction)
@@ -343,7 +343,7 @@ class Generator : CodeGenerator {
                     .addModifiers(KModifier.SUSPEND)
                     .addParameter("headers", HEADERS_CLASS_NAME)
                     .returns(
-                        ClientOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName)
+                        ClientOnlyStreamInterface::class.asClassName().parameterizedBy(inputClassName, outputClassName),
                     )
                     .addStatement(
                         "return %L",
@@ -354,7 +354,7 @@ class Generator : CodeGenerator {
                             .add(methodSpecCallBlock)
                             .unindent()
                             .addStatement(")")
-                            .build()
+                            .build(),
                     )
                     .build()
                 functions.add(clientStreamingFunction)
@@ -377,7 +377,7 @@ class Generator : CodeGenerator {
                                 .add(methodSpecCallBlock)
                                 .unindent()
                                 .addStatement(")")
-                                .build()
+                                .build(),
                         )
                         .build()
                     functions.add(unarySuspendFunction)
@@ -387,10 +387,10 @@ class Generator : CodeGenerator {
                         parameters = listOf(
                             ParameterSpec(
                                 "",
-                                ResponseMessage::class.asTypeName().parameterizedBy(outputClassName)
-                            )
+                                ResponseMessage::class.asTypeName().parameterizedBy(outputClassName),
+                            ),
                         ),
-                        returnType = Unit::class.java.asTypeName()
+                        returnType = Unit::class.java.asTypeName(),
                     )
                     val unaryCallbackFunction = FunSpec.builder(method.name.lowerCamelCase())
                         .addKdoc(sourceInfo.comment().sanitizeKdoc())
@@ -410,7 +410,7 @@ class Generator : CodeGenerator {
                                 .addStatement("onResult")
                                 .unindent()
                                 .addStatement(")")
-                                .build()
+                                .build(),
                         )
                         .build()
                     functions.add(unaryCallbackFunction)
@@ -432,7 +432,7 @@ class Generator : CodeGenerator {
                                 .add(methodSpecCallBlock)
                                 .unindent()
                                 .addStatement(")")
-                                .build()
+                                .build(),
                         )
                         .build()
                     functions.add(unarySuspendFunction)
@@ -481,7 +481,7 @@ private fun serviceClientInterfaceClassName(packageName: String, service: Descri
 
 private fun serviceClientImplementationClassName(
     packageName: String,
-    service: Descriptors.ServiceDescriptor
+    service: Descriptors.ServiceDescriptor,
 ): ClassName {
     return ClassName(packageName, "${service.name}Client")
 }

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/CodeGenerator.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/CodeGenerator.kt
@@ -28,6 +28,6 @@ interface CodeGenerator {
     fun generate(
         request: PluginProtos.CodeGeneratorRequest,
         descriptorSource: DescriptorSource,
-        response: Plugin.Response
+        response: Plugin.Response,
     )
 }

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Parameters.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Parameters.kt
@@ -27,7 +27,7 @@ internal data class Configuration(
     // Enable or disable coroutine signature generation.
     val generateCoroutineMethods: Boolean,
     // Enable or disable blocking unary signature generation.
-    val generateBlockingUnaryMethods: Boolean
+    val generateBlockingUnaryMethods: Boolean,
 )
 
 /**
@@ -43,6 +43,6 @@ internal fun parse(input: String): Configuration {
     return Configuration(
         generateCallbackMethods = parameters[CALLBACK_SIGNATURE]?.toBoolean() ?: false,
         generateCoroutineMethods = parameters[COROUTINE_SIGNATURE]?.toBoolean() ?: true, // Defaulted to true.
-        generateBlockingUnaryMethods = parameters[BLOCKING_UNARY_SIGNATURE]?.toBoolean() ?: false
+        generateBlockingUnaryMethods = parameters[BLOCKING_UNARY_SIGNATURE]?.toBoolean() ?: false,
     )
 }

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Plugin.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Plugin.kt
@@ -104,14 +104,14 @@ object Plugin {
         }
         files = asDescriptors(request.protoFileList)
         val output = CodedOutputStream.newInstance(
-            environment.outputStream()
+            environment.outputStream(),
         )
         try {
             // go ahead and write response preamble
             PluginProtos.CodeGeneratorResponse
                 .newBuilder() // add more here as more features are introduced and then supported
                 .setSupportedFeatures(
-                    toFeatureBitmask(PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL)
+                    toFeatureBitmask(PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL),
                 )
                 .build()
                 .writeTo(output)
@@ -152,7 +152,7 @@ object Plugin {
 
     private fun addAllExtensionsFromMessage(
         registry: ExtensionRegistry,
-        message: Descriptors.Descriptor
+        message: Descriptors.Descriptor,
     ) {
         for (ext in message.extensions) {
             if (ext.type == Descriptors.FieldDescriptor.Type.MESSAGE) {
@@ -182,7 +182,7 @@ object Plugin {
                     ?: throw PluginException(
                         "protoc asked plugin to generate a file " +
                             "but did not provide a descriptor for a dependency (or " +
-                            "provided it after the file that depends on it): ${protoFile.getDependency(i)}"
+                            "provided it after the file that depends on it): ${protoFile.getDependency(i)}",
                     )
                 dependencies[i] = dependency
                 i++
@@ -190,7 +190,7 @@ object Plugin {
             try {
                 filesByName[protoFile.name] = Descriptors.FileDescriptor.buildFrom(
                     protoFile,
-                    dependencies
+                    dependencies,
                 )
             } catch (e: Descriptors.DescriptorValidationException) {
                 throw PluginException(e)
@@ -268,7 +268,7 @@ object Plugin {
                 // Protocol format guarantees that concatenated messages are parsed as
                 // if they had been merged in a single message prior to being serialized.
                 PluginProtos.CodeGeneratorResponse.newBuilder().addFile(file).build().writeTo(
-                    output
+                    output,
                 )
                 output.flush()
             } catch (e: IOException) {

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/ProtoHelpers.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/ProtoHelpers.kt
@@ -42,7 +42,7 @@ private const val OUTER_CLASS_SUFFIX = "OuterClass"
  * When a key is present several times, only the last value is retained.
  */
 internal fun parseGeneratorParameter(
-    text: String
+    text: String,
 ): Map<String, String> {
     if (text.isEmpty()) {
         return emptyMap()
@@ -323,7 +323,7 @@ private fun getFieldName(field: Descriptors.FieldDescriptor): String {
  */
 private fun underscoresToCamelCaseImpl(
     input: String,
-    capNextLetter: Boolean
+    capNextLetter: Boolean,
 ): String {
     var capNextLetter = capNextLetter
     val result = StringBuilder(input.length)

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/SourceInfo.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/SourceInfo.kt
@@ -19,12 +19,12 @@ import com.google.protobuf.DescriptorProtos
 internal class SourceInfo(
     private val helper: SourceCodeHelper,
     private val descriptorSource: Plugin.DescriptorSource,
-    path: List<Int> = emptyList()
+    path: List<Int> = emptyList(),
 ) {
     constructor(
         fileDescriptor: DescriptorProtos.FileDescriptorProto,
         descriptorSource: Plugin.DescriptorSource,
-        path: List<Int> = emptyList()
+        path: List<Int> = emptyList(),
     ) : this(SourceCodeHelper(fileDescriptor), descriptorSource, path)
 
     private val path = listOf(*path.toTypedArray())
@@ -42,7 +42,7 @@ internal class SourceInfo(
  * Creates an index for the source locations.
  */
 internal class SourceCodeHelper(
-    fileDescriptorProto: DescriptorProtos.FileDescriptorProto
+    fileDescriptorProto: DescriptorProtos.FileDescriptorProto,
 ) {
     private val locations: Map<List<Int>, List<DescriptorProtos.SourceCodeInfo.Location>> = makeLocationMap(fileDescriptorProto.sourceCodeInfo.locationList)
 


### PR DESCRIPTION
Update to the latest spotless plugin, which also upgrades ktlint to 0.50.0. Ensure that spotless runs on the top-level build.gradle.kts file (currently only runs on subprojects). Fix some non-standard naming idioms for proto/json constants.