### PR TITLE
Add go build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-build-go-modules
+          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -55,6 +58,14 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Run conformance tests
         run: make conformancerun
   license-headers:
@@ -67,8 +78,11 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-license-headers-go-modules
+          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Check license headers
         run: |
           make licenseheaders
@@ -84,8 +98,11 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-test-go-modules
+          key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
+          go-version: '1.21'
           cache: false
       - uses: actions/cache@v3
         with:
@@ -57,6 +58,7 @@ jobs:
           github_token: ${{ github.token }}
       - uses: actions/setup-go@v4
         with:
+          go-version: '1.21'
           cache: false
       - uses: actions/cache@v3
         with:
@@ -74,6 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
+          go-version: '1.21'
           cache: false
       - uses: actions/cache@v3
         with:
@@ -94,6 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
+          go-version: '1.21'
           cache: false
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
There is no go.mod/go.sum in this project, while license-headers is installed and built using Go. Update each job to cache the Go modules and build cache to speed up CI builds a bit.
