### PR TITLE
Rework ConnectError to ConnectException

### DIFF
--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.conformance
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.RequestCompression
@@ -247,11 +247,11 @@ class Conformance(
                     val result = streamResults(stream.resultChannel())
                     assertThat(result.messages.map { it.payload.body.size() }).isEqualTo(sizes)
                     assertThat(result.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-                    assertThat(result.error).isInstanceOf(ConnectError::class.java)
-                    val connectError = result.error as ConnectError
-                    assertThat(connectError.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-                    assertThat(connectError.message).isEqualTo("soirée 🎉")
-                    assertThat(connectError.unpackedDetails(ErrorDetail::class)).containsExactly(
+                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
+                    val connectException = result.error as ConnectException
+                    assertThat(connectException.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
+                    assertThat(connectException.message).isEqualTo("soirée 🎉")
+                    assertThat(connectException.unpackedDetails(ErrorDetail::class)).containsExactly(
                         expectedErrorDetail,
                     )
                 } finally {
@@ -363,8 +363,8 @@ class Conformance(
             val job = async {
                 try {
                     val result = streamResults(stream.resultChannel())
-                    assertThat(result.error).isInstanceOf(ConnectError::class.java)
-                    val connectErr = result.error as ConnectError
+                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
+                    val connectErr = result.error as ConnectException
                     assertThat(connectErr.code).isEqualTo(Code.DEADLINE_EXCEEDED)
                     assertThat(result.code).isEqualTo(Code.DEADLINE_EXCEEDED)
                 } finally {
@@ -438,8 +438,8 @@ class Conformance(
                 try {
                     val result = streamResults(stream.resultChannel())
                     assertThat(result.code).isEqualTo(Code.UNIMPLEMENTED)
-                    assertThat(result.error).isInstanceOf(ConnectError::class.java)
-                    val connectErr = result.error as ConnectError
+                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
+                    val connectErr = result.error as ConnectException
                     assertThat(connectErr.code).isEqualTo(Code.UNIMPLEMENTED)
                 } finally {
                     countDownLatch.countDown()

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -247,8 +247,8 @@ class Conformance(
                     val result = streamResults(stream.resultChannel())
                     assertThat(result.messages.map { it.payload.body.size() }).isEqualTo(sizes)
                     assertThat(result.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
-                    val connectException = result.error as ConnectException
+                    assertThat(result.cause).isInstanceOf(ConnectException::class.java)
+                    val connectException = result.cause as ConnectException
                     assertThat(connectException.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
                     assertThat(connectException.message).isEqualTo("soirée 🎉")
                     assertThat(connectException.unpackedDetails(ErrorDetail::class)).containsExactly(
@@ -363,9 +363,9 @@ class Conformance(
             val job = async {
                 try {
                     val result = streamResults(stream.resultChannel())
-                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
-                    val connectErr = result.error as ConnectException
-                    assertThat(connectErr.code).isEqualTo(Code.DEADLINE_EXCEEDED)
+                    assertThat(result.cause).isInstanceOf(ConnectException::class.java)
+                    val exception = result.cause as ConnectException
+                    assertThat(exception.code).isEqualTo(Code.DEADLINE_EXCEEDED)
                     assertThat(result.code).isEqualTo(Code.DEADLINE_EXCEEDED)
                 } finally {
                     countDownLatch.countDown()
@@ -438,9 +438,9 @@ class Conformance(
                 try {
                     val result = streamResults(stream.resultChannel())
                     assertThat(result.code).isEqualTo(Code.UNIMPLEMENTED)
-                    assertThat(result.error).isInstanceOf(ConnectException::class.java)
-                    val connectErr = result.error as ConnectException
-                    assertThat(connectErr.code).isEqualTo(Code.UNIMPLEMENTED)
+                    assertThat(result.cause).isInstanceOf(ConnectException::class.java)
+                    val exception = result.cause as ConnectException
+                    assertThat(exception.code).isEqualTo(Code.UNIMPLEMENTED)
                 } finally {
                     countDownLatch.countDown()
                 }
@@ -852,7 +852,7 @@ class Conformance(
                     }
                     code = it.code
                     trailers = it.trailers
-                    error = it.error
+                    error = it.cause
                 },
             )
         }

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -44,6 +44,7 @@ import com.google.protobuf.empty
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -360,13 +361,13 @@ class Conformance(
         }
         val stream = client.streamingOutputCall()
         withContext(Dispatchers.IO) {
-            val job = async {
+            val job = launch {
                 try {
                     val result = streamResults(stream.resultChannel())
                     assertThat(result.cause).isInstanceOf(ConnectException::class.java)
-                    val exception = result.cause as ConnectException
-                    assertThat(exception.code).isEqualTo(Code.DEADLINE_EXCEEDED)
-                    assertThat(result.code).isEqualTo(Code.DEADLINE_EXCEEDED)
+                    assertThat(result.code)
+                        .withFailMessage { "Expected Code.DEADLINE_EXCEEDED but got ${result.code}" }
+                        .isEqualTo(Code.DEADLINE_EXCEEDED)
                 } finally {
                     countDownLatch.countDown()
                 }

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -177,7 +177,7 @@ class Conformance(
             },
         ).getOrThrow()
         val results = streamResults(stream.resultChannel())
-        assertThat(results.error).isNull()
+        assertThat(results.cause).isNull()
         assertThat(results.code).isEqualTo(Code.OK)
         assertThat(results.messages.map { it.payload.type }.toSet()).isEqualTo(setOf(PayloadType.COMPRESSABLE))
         assertThat(results.messages.map { it.payload.body.size() }).isEqualTo(sizes)
@@ -211,7 +211,7 @@ class Conformance(
         val results = streamResults(stream.resultChannel())
         // We've already read all the messages
         assertThat(results.messages).isEmpty()
-        assertThat(results.error).isNull()
+        assertThat(results.cause).isNull()
         assertThat(results.code).isEqualTo(Code.OK)
         stream.receiveClose()
     }
@@ -329,9 +329,9 @@ class Conformance(
         testServiceConnectClient.unaryCall(message) { response ->
             assertThat(response.code).isEqualTo(Code.UNKNOWN)
             response.failure { errorResponse ->
-                assertThat(errorResponse.error).isNotNull()
+                assertThat(errorResponse.cause).isNotNull()
                 assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
-                assertThat(errorResponse.error.message).isEqualTo("test status message")
+                assertThat(errorResponse.cause.message).isEqualTo("test status message")
                 countDownLatch.countDown()
             }
             response.success {
@@ -392,7 +392,7 @@ class Conformance(
             },
         ) { response ->
             response.failure { errorResponse ->
-                val error = errorResponse.error
+                val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.UNKNOWN)
                 assertThat(response.code).isEqualTo(Code.UNKNOWN)
                 assertThat(error.message).isEqualTo(statusMessage)
@@ -461,7 +461,7 @@ class Conformance(
         testServiceConnectClient.failUnaryCall(simpleRequest {}) { response ->
             assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
             response.failure { errorResponse ->
-                val error = errorResponse.error
+                val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
                 assertThat(error.message).isEqualTo("soirée 🎉")
                 val connectErrorDetails = error.unpackedDetails(ErrorDetail::class)
@@ -544,9 +544,9 @@ class Conformance(
         val response = testServiceConnectClient.unaryCallBlocking(message).execute()
         assertThat(response.code).isEqualTo(Code.UNKNOWN)
         response.failure { errorResponse ->
-            assertThat(errorResponse.error).isNotNull()
+            assertThat(errorResponse.cause).isNotNull()
             assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
-            assertThat(errorResponse.error.message).isEqualTo("test status message")
+            assertThat(errorResponse.cause.message).isEqualTo("test status message")
         }
         response.success {
             fail<Unit>("unexpected success")
@@ -566,7 +566,7 @@ class Conformance(
             },
         ).execute()
         response.failure { errorResponse ->
-            val error = errorResponse.error
+            val error = errorResponse.cause
             assertThat(error.code).isEqualTo(Code.UNKNOWN)
             assertThat(response.code).isEqualTo(Code.UNKNOWN)
             assertThat(error.message).isEqualTo(statusMessage)
@@ -597,7 +597,7 @@ class Conformance(
         val response = testServiceConnectClient.failUnaryCallBlocking(simpleRequest {}).execute()
         assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
         response.failure { errorResponse ->
-            val error = errorResponse.error
+            val error = errorResponse.cause
             assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
             assertThat(error.message).isEqualTo("soirée 🎉")
             val connectErrorDetails = error.unpackedDetails(ErrorDetail::class)
@@ -692,9 +692,9 @@ class Conformance(
         testServiceConnectClient.unaryCall(message) { response ->
             assertThat(response.code).isEqualTo(Code.UNKNOWN)
             response.failure { errorResponse ->
-                assertThat(errorResponse.error).isNotNull()
+                assertThat(errorResponse.cause).isNotNull()
                 assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
-                assertThat(errorResponse.error.message).isEqualTo("test status message")
+                assertThat(errorResponse.cause.message).isEqualTo("test status message")
                 countDownLatch.countDown()
             }
             response.success {
@@ -720,7 +720,7 @@ class Conformance(
             },
         ) { response ->
             response.failure { errorResponse ->
-                val error = errorResponse.error
+                val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.UNKNOWN)
                 assertThat(response.code).isEqualTo(Code.UNKNOWN)
                 assertThat(error.message).isEqualTo(statusMessage)
@@ -766,7 +766,7 @@ class Conformance(
         testServiceConnectClient.failUnaryCall(simpleRequest {}) { response ->
             assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
             response.failure { errorResponse ->
-                val error = errorResponse.error
+                val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
                 assertThat(error.message).isEqualTo("soirée 🎉")
                 val connectErrorDetails = error.unpackedDetails(ErrorDetail::class)
@@ -817,7 +817,7 @@ class Conformance(
         val messages: List<Output>,
         val code: Code,
         val trailers: Trailers,
-        val error: Throwable?,
+        val cause: Throwable?,
     )
 
     /*

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -72,7 +72,7 @@ class Main {
                         },
                         onCompletion = { result ->
                             if (result.code != Code.OK) {
-                                val connectErr = result.connectError()
+                                val connectErr = result.connectException()
                                 if (connectErr != null) {
                                     throw connectErr
                                 }

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -72,9 +72,9 @@ class Main {
                         },
                         onCompletion = { result ->
                             if (result.code != Code.OK) {
-                                val connectErr = result.connectException()
-                                if (connectErr != null) {
-                                    throw connectErr
+                                val exception = result.connectException()
+                                if (exception != null) {
+                                    throw exception
                                 }
                                 throw ConnectException(code = result.code, metadata = result.trailers)
                             }

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.examples.kotlin
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ElizaServiceClient
 import com.connectrpc.eliza.v1.converseRequest
@@ -76,7 +76,7 @@ class Main {
                                 if (connectErr != null) {
                                     throw connectErr
                                 }
-                                throw ConnectError(code = result.code, metadata = result.trailers)
+                                throw ConnectException(code = result.code, metadata = result.trailers)
                             }
                         },
                     )

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -72,7 +72,7 @@ class Main {
                         },
                         onCompletion = { result ->
                             if (result.code != Code.OK) {
-                                val connectErr = result.connectError()
+                                val connectErr = result.connectException()
                                 if (connectErr != null) {
                                     throw connectErr
                                 }

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -72,9 +72,9 @@ class Main {
                         },
                         onCompletion = { result ->
                             if (result.code != Code.OK) {
-                                val connectErr = result.connectException()
-                                if (connectErr != null) {
-                                    throw connectErr
+                                val exception = result.connectException()
+                                if (exception != null) {
+                                    throw exception
                                 }
                                 throw ConnectException(code = result.code, metadata = result.trailers)
                             }

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.examples.kotlin
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ElizaServiceClient
 import com.connectrpc.eliza.v1.converseRequest
@@ -76,7 +76,7 @@ class Main {
                                 if (connectErr != null) {
                                     throw connectErr
                                 }
-                                throw ConnectError(code = result.code, metadata = result.trailers)
+                                throw ConnectException(code = result.code, metadata = result.trailers)
                             }
                         },
                     )

--- a/library/src/main/kotlin/com/connectrpc/ConnectException.kt
+++ b/library/src/main/kotlin/com/connectrpc/ConnectException.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  * Typed error provided by Connect RPCs that may optionally wrap additional typed custom errors
  * using [details].
  */
-data class ConnectError(
+data class ConnectException(
     // The resulting status code.
     val code: Code,
     private val errorDetailParser: ErrorDetailParser? = null,
@@ -32,7 +32,7 @@ data class ConnectError(
     val details: List<ConnectErrorDetail> = emptyList(),
     // Additional key-values that were provided by the server.
     val metadata: Headers = emptyMap(),
-) : Throwable(message, exception) {
+) : Exception(message, exception) {
 
     /**
      * Unpacks values from [details] and returns the first matching error, if any.
@@ -51,10 +51,10 @@ data class ConnectError(
     }
 
     /**
-     * Creates a new [ConnectError] with the specified [ErrorDetailParser].
+     * Creates a new [ConnectException] with the specified [ErrorDetailParser].
      */
-    fun setErrorParser(errorParser: ErrorDetailParser): ConnectError {
-        return ConnectError(
+    fun setErrorParser(errorParser: ErrorDetailParser): ConnectException {
+        return ConnectException(
             code,
             errorParser,
             message,

--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -42,7 +42,7 @@ sealed class ResponseMessage<Output>(
 
     class Failure<Output>(
         // The error.
-        val error: ConnectError,
+        val error: ConnectException,
         // The status code of the response.
         override val code: Code,
         // Response headers specified by the server.

--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -41,8 +41,8 @@ sealed class ResponseMessage<Output>(
     }
 
     class Failure<Output>(
-        // The error.
-        val error: ConnectException,
+        // The problem.
+        val cause: ConnectException,
         // The status code of the response.
         override val code: Code,
         // Response headers specified by the server.
@@ -51,7 +51,7 @@ sealed class ResponseMessage<Output>(
         override val trailers: Trailers,
     ) : ResponseMessage<Output>(code, headers, trailers) {
         override fun toString(): String {
-            return "Failure{error=$error,code=$code,headers=$headers,trailers=$trailers}"
+            return "Failure{cause=$cause,code=$code,headers=$headers,trailers=$trailers}"
         }
     }
 
@@ -77,7 +77,7 @@ sealed class ResponseMessage<Output>(
 fun ResponseMessage<*>.exceptionOrNull(): Throwable? {
     return when (this) {
         is ResponseMessage.Success -> null
-        is ResponseMessage.Failure -> this.error
+        is ResponseMessage.Failure -> this.cause
     }
 }
 
@@ -93,7 +93,7 @@ inline fun <R, T> ResponseMessage<T>.fold(
 ): R {
     return when (this) {
         is ResponseMessage.Success -> onSuccess(this.message)
-        is ResponseMessage.Failure -> onFailure(this.error)
+        is ResponseMessage.Failure -> onFailure(this.cause)
     }
 }
 
@@ -117,7 +117,7 @@ fun <T> ResponseMessage<T>.getOrDefault(defaultValue: T): T {
 inline fun <R, T : R> ResponseMessage<T>.getOrElse(onFailure: (exception: Throwable) -> R): R {
     return when (this) {
         is ResponseMessage.Success -> this.message
-        is ResponseMessage.Failure -> onFailure(this.error)
+        is ResponseMessage.Failure -> onFailure(this.cause)
     }
 }
 
@@ -139,6 +139,6 @@ fun <T> ResponseMessage<T>.getOrNull(): T? {
 fun <T> ResponseMessage<T>.getOrThrow(): T {
     return when (this) {
         is ResponseMessage.Success -> this.message
-        is ResponseMessage.Failure -> throw this.error
+        is ResponseMessage.Failure -> throw this.cause
     }
 }

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -37,7 +37,7 @@ sealed class StreamResult<Output> {
     // Stream is complete. Provides the end status code and optionally an error and trailers.
     class Complete<Output>(val code: Code, val error: Throwable? = null, val trailers: Trailers = emptyMap()) : StreamResult<Output>() {
         /**
-         * Get the ConnectError from the result.
+         * Get the ConnectException from the result.
          *
          * @return The [ConnectException] if present, null otherwise.
          */

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -39,10 +39,10 @@ sealed class StreamResult<Output> {
         /**
          * Get the ConnectError from the result.
          *
-         * @return The [ConnectError] if present, null otherwise.
+         * @return The [ConnectException] if present, null otherwise.
          */
-        fun connectError(): ConnectError? {
-            if (error is ConnectError) {
+        fun connectError(): ConnectException? {
+            if (error is ConnectException) {
                 return error
             }
             return null

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -35,16 +35,16 @@ sealed class StreamResult<Output> {
     }
 
     // Stream is complete. Provides the end status code and optionally an error and trailers.
-    class Complete<Output>(val code: Code, val error: Throwable? = null, val trailers: Trailers = emptyMap()) : StreamResult<Output>() {
+    class Complete<Output>(val code: Code, val cause: Throwable? = null, val trailers: Trailers = emptyMap()) : StreamResult<Output>() {
         /**
          * Get the ConnectException from the result.
          *
          * @return The [ConnectException] if present, null otherwise.
          */
-        fun connectException() = error as? ConnectException
+        fun connectException() = cause as? ConnectException
 
         override fun toString(): String {
-            return "Complete{code=$code,error=$error,trailers=$trailers}"
+            return "Complete{code=$code,cause=$cause,trailers=$trailers}"
         }
     }
 

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -41,12 +41,7 @@ sealed class StreamResult<Output> {
          *
          * @return The [ConnectException] if present, null otherwise.
          */
-        fun connectError(): ConnectException? {
-            if (error is ConnectException) {
-                return error
-            }
-            return null
-        }
+        fun connectException() = error as? ConnectException
 
         override fun toString(): String {
             return "Complete{code=$code,error=$error,trailers=$trailers}"

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
@@ -38,5 +38,5 @@ class HTTPResponse(
     // null in cases where no response was received from the server.
     val tracingInfo: TracingInfo?,
     // The accompanying error, if the request failed.
-    val error: ConnectException? = null,
+    val cause: ConnectException? = null,
 )

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.http
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.Trailers
 import okio.BufferedSource
@@ -38,5 +38,5 @@ class HTTPResponse(
     // null in cases where no response was received from the server.
     val tracingInfo: TracingInfo?,
     // The accompanying error, if the request failed.
-    val error: ConnectError? = null,
+    val error: ConnectException? = null,
 )

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -40,7 +40,7 @@ internal class ClientOnlyStream<Input, Output>(
             // in the channel (headers, 1* messages, completion) and have to resort to fold()/maybeFold() to interpret
             // the overall results.
             // Additionally, ResponseMessage.Success and ResponseMessage.Failure shouldn't be necessary for client use.
-            // We should throw ConnectError for failure and only have users have to deal with success messages.
+            // We should throw ConnectException for failure and only have users have to deal with success messages.
             var headers: Headers = emptyMap()
             var message: Output? = null
             var trailers: Headers = emptyMap()
@@ -57,7 +57,7 @@ internal class ClientOnlyStream<Input, Output>(
                     onCompletion = {
                         code = it.code
                         trailers = it.trailers
-                        val resultErr = it.error
+                        val resultErr = it.cause
                         if (resultErr != null) {
                             error = if (resultErr is ConnectException) {
                                 resultErr

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -17,7 +17,7 @@ package com.connectrpc.impl
 import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.ClientOnlyStreamInterface
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.ResponseMessage
 
@@ -45,7 +45,7 @@ internal class ClientOnlyStream<Input, Output>(
             var message: Output? = null
             var trailers: Headers = emptyMap()
             var code: Code? = null
-            var error: ConnectError? = null
+            var error: ConnectException? = null
             for (result in resultChannel) {
                 result.maybeFold(
                     onHeaders = {
@@ -59,10 +59,10 @@ internal class ClientOnlyStream<Input, Output>(
                         trailers = it.trailers
                         val resultErr = it.error
                         if (resultErr != null) {
-                            error = if (resultErr is ConnectError) {
+                            error = if (resultErr is ConnectException) {
                                 resultErr
                             } else {
-                                ConnectError(code ?: Code.UNKNOWN, message = error?.message, exception = error, metadata = trailers)
+                                ConnectException(code ?: Code.UNKNOWN, message = error?.message, exception = error, metadata = trailers)
                             }
                         }
                     },
@@ -72,14 +72,14 @@ internal class ClientOnlyStream<Input, Output>(
                 return ResponseMessage.Failure(error!!, code ?: Code.UNKNOWN, headers, trailers)
             }
             if (code == null) {
-                return ResponseMessage.Failure(ConnectError(Code.UNKNOWN, message = "unknown status code"), Code.UNKNOWN, headers, trailers)
+                return ResponseMessage.Failure(ConnectException(Code.UNKNOWN, message = "unknown status code"), Code.UNKNOWN, headers, trailers)
             }
             if (message != null) {
                 return ResponseMessage.Success(message!!, code!!, headers, trailers)
             }
             // We didn't receive an error at any point, however we didn't get a response message either.
             return ResponseMessage.Failure(
-                ConnectError(Code.UNKNOWN, message = "missing response message"),
+                ConnectException(Code.UNKNOWN, message = "missing response message"),
                 code!!,
                 headers,
                 trailers,

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -204,7 +204,7 @@ class ProtocolClient(
                 is StreamResult.Complete -> {
                     isComplete = true
                     StreamResult.Complete(
-                        streamResult.connectError()?.code ?: Code.OK,
+                        streamResult.connectException()?.code ?: Code.OK,
                         error = streamResult.error,
                         trailers = streamResult.trailers,
                     )

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -73,11 +73,11 @@ class ProtocolClient(
             val cancelable = httpClient.unary(finalRequest) { httpResponse ->
                 val finalResponse = unaryFunc.responseFunction(httpResponse)
                 val code = finalResponse.code
-                val connectError = finalResponse.error?.setErrorParser(serializationStrategy.errorDetailParser())
-                if (connectError != null) {
+                val exception = finalResponse.cause?.setErrorParser(serializationStrategy.errorDetailParser())
+                if (exception != null) {
                     onResult(
                         ResponseMessage.Failure(
-                            connectError,
+                            exception,
                             code,
                             finalResponse.headers,
                             finalResponse.trailers,
@@ -205,7 +205,7 @@ class ProtocolClient(
                     isComplete = true
                     StreamResult.Complete(
                         streamResult.connectException()?.code ?: Code.OK,
-                        error = streamResult.error,
+                        cause = streamResult.cause,
                         trailers = streamResult.trailers,
                     )
                 }

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
@@ -16,8 +16,8 @@ package com.connectrpc.protocols
 
 import com.connectrpc.Code
 import com.connectrpc.Codec
-import com.connectrpc.ConnectException
 import com.connectrpc.ConnectErrorDetail
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.Idempotency
 import com.connectrpc.Interceptor

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
@@ -169,7 +169,7 @@ internal class ConnectInterceptor(
                     },
                     onCompletion = { result ->
                         val streamTrailers = result.trailers
-                        val error = result.connectError()
+                        val error = result.connectException()
                         StreamResult.Complete(error?.code ?: Code.OK, error = error, streamTrailers)
                     },
                 )

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
@@ -15,8 +15,8 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectException
 import com.connectrpc.ConnectErrorDetail
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.SerializationStrategy
 import okio.ByteString

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ConnectErrorDetail
 import com.connectrpc.Headers
 import com.connectrpc.SerializationStrategy
@@ -37,13 +37,13 @@ internal data class GRPCCompletion(
     val metadata: Headers,
 )
 
-internal fun grpcCompletionToConnectError(completion: GRPCCompletion?, serializationStrategy: SerializationStrategy, error: Throwable?): ConnectError? {
-    if (error is ConnectError) {
+internal fun grpcCompletionToConnectError(completion: GRPCCompletion?, serializationStrategy: SerializationStrategy, error: Throwable?): ConnectException? {
+    if (error is ConnectException) {
         return error
     }
     val code = completion?.code ?: Code.UNKNOWN
     if (error != null || code != Code.OK) {
-        return ConnectError(
+        return ConnectException(
             code = code,
             errorDetailParser = serializationStrategy.errorDetailParser(),
             message = completion?.message?.utf8(),

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
@@ -40,17 +40,17 @@ internal data class GRPCCompletion(
      * Converts a completion into a [ConnectException] if the completion failed or if a throwable is passed
      * @return a ConnectException on failure, null otherwise
      */
-    fun toConnectExceptionOrNull(serializationStrategy: SerializationStrategy, t: Throwable? = null): ConnectException? {
-        if (t is ConnectException) {
-            return t
+    fun toConnectExceptionOrNull(serializationStrategy: SerializationStrategy, cause: Throwable? = null): ConnectException? {
+        if (cause is ConnectException) {
+            return cause
         }
 
-        if (t != null || code != Code.OK) {
+        if (cause != null || code != Code.OK) {
             return ConnectException(
                 code = code,
                 errorDetailParser = serializationStrategy.errorDetailParser(),
                 message = message.utf8(),
-                exception = t,
+                exception = cause,
                 details = errorDetails,
                 metadata = metadata,
             )

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -78,7 +78,7 @@ internal class GRPCInterceptor(
                         headers = headers,
                         message = Buffer(),
                         trailers = trailers,
-                        error = response.error,
+                        cause = response.cause,
                         tracingInfo = response.tracingInfo,
                     )
                 }
@@ -94,7 +94,7 @@ internal class GRPCInterceptor(
                         headers = headers,
                         message = message,
                         trailers = trailers,
-                        error = response.error,
+                        cause = response.cause,
                         tracingInfo = response.tracingInfo,
                     )
                 } else {
@@ -108,7 +108,7 @@ internal class GRPCInterceptor(
                         headers = headers,
                         message = result,
                         trailers = trailers,
-                        error = ConnectException(
+                        cause = ConnectException(
                             code = code,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = completion?.message?.utf8(),
@@ -144,7 +144,7 @@ internal class GRPCInterceptor(
                             val exception = completion.toConnectExceptionOrNull(serializationStrategy)
                             return@fold StreamResult.Complete(
                                 code = exception?.code ?: Code.OK,
-                                error = exception,
+                                cause = exception,
                                 trailers = headers,
                             )
                         }
@@ -164,11 +164,11 @@ internal class GRPCInterceptor(
                         if (completion != null) {
                             val exception = completion.toConnectExceptionOrNull(
                                 serializationStrategy,
-                                result.error
+                                result.cause
                             )
                             StreamResult.Complete(
                                 code = exception?.code ?: Code.OK,
-                                error = exception,
+                                cause = exception,
                                 trailers = trailers,
                             )
                         } else {

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -164,7 +164,7 @@ internal class GRPCInterceptor(
                         if (completion != null) {
                             val exception = completion.toConnectExceptionOrNull(
                                 serializationStrategy,
-                                result.cause
+                                result.cause,
                             )
                             StreamResult.Complete(
                                 code = exception?.code ?: Code.OK,

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.Interceptor
 import com.connectrpc.ProtocolClientConfig
@@ -108,7 +108,7 @@ internal class GRPCInterceptor(
                         headers = headers,
                         message = result,
                         trailers = trailers,
-                        error = ConnectError(
+                        error = ConnectException(
                             code = code,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = completion?.message?.utf8(),

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -174,8 +174,7 @@ internal class GRPCInterceptor(
                                 trailers = trailers,
                             )
                         } else {
-                            val exception = ConnectException(result.code)
-                            StreamResult.Complete(exception.code, exception, trailers)
+                            result
                         }
                     },
                 )

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -136,7 +136,7 @@ internal class GRPCInterceptor(
                 Envelope.pack(buffer, requestCompression?.compressionPool, requestCompression?.minBytes)
             },
             streamResultFunction = { res ->
-                val streamResult = res.fold(
+                res.fold(
                     onHeaders = { result ->
                         val headers = result.headers
                         val completion = completionParser.parse(headers, emptyMap())
@@ -172,12 +172,11 @@ internal class GRPCInterceptor(
                                 trailers = trailers,
                             )
                         } else {
-                            val exception = ConnectException(Code.UNKNOWN)
+                            val exception = ConnectException(result.code)
                             StreamResult.Complete(exception.code, exception, trailers)
                         }
                     },
                 )
-                streamResult
             },
         )
     }

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -189,10 +189,9 @@ internal class GRPCWebInterceptor(
                         responseCompressionPool = clientConfig.compressionPool(responseHeaders[GRPC_ENCODING]?.first())
                         val completion = completionParser.parse(responseHeaders, emptyMap())
                         if (completion != null) {
-                            val connectError = grpcCompletionToConnectError(completion, serializationStrategy, null)
                             return@fold StreamResult.Complete(
                                 code = completion.code,
-                                error = connectError,
+                                error = completion.toConnectExceptionOrNull(serializationStrategy),
                                 trailers = responseHeaders,
                             )
                         }
@@ -207,10 +206,9 @@ internal class GRPCWebInterceptor(
                             val streamTrailers = parseGrpcWebTrailer(unpackedMessage)
                             val completion = completionParser.parse(emptyMap(), streamTrailers)
                             val code = completion!!.code
-                            val connectError = grpcCompletionToConnectError(completion, serializationStrategy, null)
                             return@fold StreamResult.Complete(
                                 code = code,
-                                error = connectError,
+                                error = completion.toConnectExceptionOrNull(serializationStrategy),
                                 trailers = streamTrailers,
                             )
                         }

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.Interceptor
 import com.connectrpc.ProtocolClientConfig
@@ -106,7 +106,7 @@ internal class GRPCWebInterceptor(
                         headers = headers,
                         message = result,
                         trailers = trailers,
-                        error = ConnectError(
+                        error = ConnectException(
                             code = code,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = completion?.message?.utf8(),
@@ -146,7 +146,7 @@ internal class GRPCWebInterceptor(
                         val result = Buffer()
                         val errorMessage = completionWithMessage.message
                         result.write(errorMessage)
-                        ConnectError(
+                        ConnectException(
                             code = finalCode,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = errorMessage.utf8(),

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -79,7 +79,7 @@ internal class GRPCWebInterceptor(
                         headers = headers,
                         message = Buffer(),
                         trailers = emptyMap(),
-                        error = response.error,
+                        cause = response.cause,
                         tracingInfo = response.tracingInfo,
                     )
                 }
@@ -106,7 +106,7 @@ internal class GRPCWebInterceptor(
                         headers = headers,
                         message = result,
                         trailers = trailers,
-                        error = ConnectException(
+                        cause = ConnectException(
                             code = code,
                             errorDetailParser = serializationStrategy.errorDetailParser(),
                             message = completion?.message?.utf8(),
@@ -160,7 +160,7 @@ internal class GRPCWebInterceptor(
                         headers = headers,
                         message = unpacked,
                         trailers = finalTrailers,
-                        error = error,
+                        cause = error,
                         tracingInfo = response.tracingInfo,
                     )
                 }
@@ -191,7 +191,7 @@ internal class GRPCWebInterceptor(
                         if (completion != null) {
                             return@fold StreamResult.Complete(
                                 code = completion.code,
-                                error = completion.toConnectExceptionOrNull(serializationStrategy),
+                                cause = completion.toConnectExceptionOrNull(serializationStrategy),
                                 trailers = responseHeaders,
                             )
                         }
@@ -208,7 +208,7 @@ internal class GRPCWebInterceptor(
                             val code = completion!!.code
                             return@fold StreamResult.Complete(
                                 code = code,
-                                error = completion.toConnectExceptionOrNull(serializationStrategy),
+                                cause = completion.toConnectExceptionOrNull(serializationStrategy),
                                 trailers = streamTrailers,
                             )
                         }

--- a/library/src/test/kotlin/com/connectrpc/ConnectExceptionTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/ConnectExceptionTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-class ConnectErrorTest {
+class ConnectExceptionTest {
     private val errorDetailParser: ErrorDetailParser = mock { }
 
     @Test
@@ -30,7 +30,7 @@ class ConnectErrorTest {
             "value".encodeUtf8(),
         )
         whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
-        val connectError = ConnectError(
+        val connectException = ConnectException(
             code = Code.UNKNOWN,
             details = listOf(
                 errorDetail,
@@ -38,7 +38,7 @@ class ConnectErrorTest {
             ),
             errorDetailParser = errorDetailParser,
         )
-        val parsedResult = connectError.unpackedDetails(String::class)
+        val parsedResult = connectException.unpackedDetails(String::class)
         assertThat(parsedResult).contains("unpacked_value", "unpacked_value")
     }
 
@@ -49,13 +49,13 @@ class ConnectErrorTest {
             "value".encodeUtf8(),
         )
         whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
-        val connectError = ConnectError(
+        val connectException = ConnectException(
             code = Code.UNKNOWN,
             details = listOf(
                 errorDetail,
             ),
         )
-        val parsedResult = connectError.unpackedDetails(String::class)
+        val parsedResult = connectException.unpackedDetails(String::class)
         assertThat(parsedResult).isEmpty()
     }
 }

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -126,7 +126,7 @@ class InterceptorChainTest {
                         it.message,
                         it.trailers,
                         it.tracingInfo,
-                        it.error,
+                        it.cause,
                     )
                 },
             )

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -245,9 +245,9 @@ class ConnectInterceptorTest {
                 tracingInfo = null,
             ),
         )
-        assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        assertThat(response.error!!.message).isEqualTo("no more resources!")
-        val connectErrorDetail = response.error!!.details.singleOrNull()!!
+        assertThat(response.cause!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
+        assertThat(response.cause!!.message).isEqualTo("no more resources!")
+        val connectErrorDetail = response.cause!!.details.singleOrNull()!!
         assertThat(connectErrorDetail.type).isEqualTo("type")
         assertThat(connectErrorDetail.payload).isEqualTo("value".encodeUtf8())
     }
@@ -271,7 +271,7 @@ class ConnectInterceptorTest {
                 tracingInfo = null,
             ),
         )
-        assertThat(response.error!!.code).isEqualTo(Code.UNAVAILABLE)
+        assertThat(response.cause!!.code).isEqualTo(Code.UNAVAILABLE)
     }
 
     @Test
@@ -533,9 +533,9 @@ class ConnectInterceptorTest {
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
         assertThat(completion.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        val connectError = completion.connectException()!!
-        assertThat(connectError.message).isEqualTo("no more resources!")
-        val errorDetail = connectError.details.single()
+        val exception = completion.connectException()!!
+        assertThat(exception.message).isEqualTo("no more resources!")
+        val errorDetail = exception.details.single()
         assertThat(errorDetail.type).isEqualTo("type")
         assertThat(errorDetail.payload).isEqualTo("value".encodeUtf8())
     }
@@ -595,7 +595,7 @@ class ConnectInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectException(
+                cause = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -16,7 +16,7 @@ package com.connectrpc.protocols
 
 import com.connectrpc.Code
 import com.connectrpc.Codec
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.Idempotency
 import com.connectrpc.Method.GET_METHOD
@@ -595,7 +595,7 @@ class ConnectInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectError(
+                error = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -533,7 +533,7 @@ class ConnectInterceptorTest {
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
         assertThat(completion.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        val connectError = completion.connectError()!!
+        val connectError = completion.connectException()!!
         assertThat(connectError.message).isEqualTo("no more resources!")
         val errorDetail = connectError.details.single()
         assertThat(errorDetail.type).isEqualTo("type")

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -259,9 +259,9 @@ class GRPCInterceptorTest {
                 tracingInfo = null,
             ),
         )
-        assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        assertThat(response.error!!.message).isEqualTo("no more resources!")
-        val connectErrorDetail = response.error!!.details.singleOrNull()!!
+        assertThat(response.cause!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
+        assertThat(response.cause!!.message).isEqualTo("no more resources!")
+        val connectErrorDetail = response.cause!!.details.singleOrNull()!!
         assertThat(connectErrorDetail.type).isEqualTo("type")
         assertThat(connectErrorDetail.payload).isEqualTo("value".encodeUtf8())
     }
@@ -519,7 +519,7 @@ class GRPCInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectException(
+                cause = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -15,8 +15,8 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectException
 import com.connectrpc.ConnectErrorDetail
+import com.connectrpc.ConnectException
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.MethodSpec
 import com.connectrpc.ProtocolClientConfig

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ConnectErrorDetail
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.MethodSpec
@@ -519,7 +519,7 @@ class GRPCInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectError(
+                error = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -520,7 +520,7 @@ class GRPCWebInterceptorTest {
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
         assertThat(completion.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        val connectError = completion.connectError()!!
+        val connectError = completion.connectException()!!
         assertThat(connectError.message).isEqualTo("no more resources!")
     }
 

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -225,7 +225,7 @@ class GRPCWebInterceptorTest {
                 tracingInfo = null,
             ),
         )
-        assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
+        assertThat(response.cause!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
     }
 
     @Test
@@ -284,7 +284,7 @@ class GRPCWebInterceptorTest {
                 tracingInfo = null,
             ),
         )
-        assertThat(response.error!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
+        assertThat(response.cause!!.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
     }
 
     @Test
@@ -520,8 +520,8 @@ class GRPCWebInterceptorTest {
         assertThat(result).isOfAnyClassIn(StreamResult.Complete::class.java)
         val completion = result as StreamResult.Complete
         assertThat(completion.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
-        val connectError = completion.connectException()!!
-        assertThat(connectError.message).isEqualTo("no more resources!")
+        val exception = completion.connectException()!!
+        assertThat(exception.message).isEqualTo("no more resources!")
     }
 
     @Test
@@ -560,7 +560,7 @@ class GRPCWebInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectException(
+                cause = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.MethodSpec
 import com.connectrpc.ProtocolClientConfig
@@ -560,7 +560,7 @@ class GRPCWebInterceptorTest {
         val result = streamFunction.streamResultFunction(
             StreamResult.Complete(
                 code = Code.UNKNOWN,
-                error = ConnectError(
+                error = ConnectException(
                     Code.UNKNOWN,
                     message = "error_message",
                 ),

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -74,7 +74,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                                 headers = emptyMap(),
                                 message = Buffer(),
                                 trailers = emptyMap(),
-                                error = ConnectException(
+                                cause = ConnectException(
                                     code,
                                     message = e.message,
                                     exception = e,
@@ -110,7 +110,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                     headers = emptyMap(),
                     message = Buffer(),
                     trailers = emptyMap(),
-                    error = ConnectException(
+                    cause = ConnectException(
                         Code.UNKNOWN,
                         message = e.message,
                         exception = e,

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.okhttp
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.StreamResult
 import com.connectrpc.http.Cancelable
 import com.connectrpc.http.HTTPClientInterface
@@ -74,7 +74,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                                 headers = emptyMap(),
                                 message = Buffer(),
                                 trailers = emptyMap(),
-                                error = ConnectError(
+                                error = ConnectException(
                                     code,
                                     message = e.message,
                                     exception = e,
@@ -110,7 +110,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
                     headers = emptyMap(),
                     message = Buffer(),
                     trailers = emptyMap(),
-                    error = ConnectError(
+                    error = ConnectException(
                         Code.UNKNOWN,
                         message = e.message,
                         exception = e,

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.okhttp
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectError
+import com.connectrpc.ConnectException
 import com.connectrpc.StreamResult
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.Stream
@@ -87,7 +87,7 @@ private class ResponseCallback(
         runBlocking {
             if (e is InterruptedIOException) {
                 if (e.message == "timeout") {
-                    val error = ConnectError(code = Code.DEADLINE_EXCEEDED)
+                    val error = ConnectException(code = Code.DEADLINE_EXCEEDED)
                     onResult(StreamResult.Complete(Code.DEADLINE_EXCEEDED, error = error))
                     return@runBlocking
                 }
@@ -106,7 +106,7 @@ private class ResponseCallback(
                 val finalResult = StreamResult.Complete<Buffer>(
                     code = code,
                     trailers = response.safeTrailers() ?: emptyMap(),
-                    error = ConnectError(code = code),
+                    error = ConnectException(code = code),
                 )
                 onResult(finalResult)
                 return@runBlocking

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -88,11 +88,11 @@ private class ResponseCallback(
             if (e is InterruptedIOException) {
                 if (e.message == "timeout") {
                     val error = ConnectException(code = Code.DEADLINE_EXCEEDED)
-                    onResult(StreamResult.Complete(Code.DEADLINE_EXCEEDED, error = error))
+                    onResult(StreamResult.Complete(Code.DEADLINE_EXCEEDED, cause = error))
                     return@runBlocking
                 }
             }
-            onResult(StreamResult.Complete(Code.UNKNOWN, error = e))
+            onResult(StreamResult.Complete(Code.UNKNOWN, cause = e))
         }
     }
 
@@ -106,7 +106,7 @@ private class ResponseCallback(
                 val finalResult = StreamResult.Complete<Buffer>(
                     code = code,
                     trailers = response.safeTrailers() ?: emptyMap(),
-                    error = ConnectException(code = code),
+                    cause = ConnectException(code = code),
                 )
                 onResult(finalResult)
                 return@runBlocking
@@ -130,7 +130,7 @@ private class ResponseCallback(
                         val finalResult = StreamResult.Complete<Buffer>(
                             code = code,
                             trailers = response.safeTrailers() ?: emptyMap(),
-                            error = exception,
+                            cause = exception,
                         )
                         onResult(finalResult)
                     }


### PR DESCRIPTION
Exceptions that might be caught should not extend throwable. Throwable
is the subtype of both Exception and Error. The latter indicates a
critical failure and should only be caught in very rare circumstances.
This change renames the class and makes the supertype more specific
to suggest that catching this throwable is reasonable.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/connectrpc/connect-kotlin/blob/main/.github/CONTRIBUTING.md

**Note:** This is a source-breaking change, which was briefly discussed in slack.
