### PR TITLE
Update dependencies and fix javadoc artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,11 +51,23 @@ allprojects {
     spotless {
         isEnforceCheck = false // Disables lint on gradle builds.
         kotlin {
-            ktlint().editorConfigOverride(mapOf("ktlint_experimental" to "enabled"))
+            ktlint().editorConfigOverride(
+                mapOf(
+                    "ktlint_experimental" to "enabled",
+                    // Disabled until https://github.com/pinterest/ktlint/pull/2273 is released
+                    "ktlint_standard_function-expression-body" to "disabled",
+                    ),
+            )
             target("**/*.kt")
         }
         kotlinGradle {
-            ktlint().editorConfigOverride(mapOf("ktlint_experimental" to "enabled"))
+            ktlint().editorConfigOverride(
+                mapOf(
+                    "ktlint_experimental" to "enabled",
+                    // Disabled until https://github.com/pinterest/ktlint/pull/2273 is released
+                    "ktlint_standard_function-expression-body" to "disabled",
+                    ),
+                )
             target("**/*.kts")
         }
     }
@@ -76,16 +88,8 @@ allprojects {
     }
     tasks.withType<DokkaTask>().configureEach {
         dokkaSourceSets.configureEach {
-            reportUndocumented.set(false)
             skipDeprecated.set(true)
             jdkVersion.set(8)
-            perPackageOption {
-                matchingRegex.set("build\\.buf.*")
-                suppress.set(true)
-            }
-        }
-        if (name == "dokkaGfm") {
-            outputDirectory.set(project.file("${project.rootDir}/docs/3.x"))
         }
     }
     plugins.withId("com.vanniktech.maven.publish.base") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ allprojects {
                     "ktlint_experimental" to "enabled",
                     // Disabled until https://github.com/pinterest/ktlint/pull/2273 is released
                     "ktlint_standard_function-expression-body" to "disabled",
-                    ),
+                ),
             )
             target("**/*.kt")
         }
@@ -66,8 +66,8 @@ allprojects {
                     "ktlint_experimental" to "enabled",
                     // Disabled until https://github.com/pinterest/ktlint/pull/2273 is released
                     "ktlint_standard_function-expression-body" to "disabled",
-                    ),
-                )
+                ),
+            )
             target("**/*.kts")
         }
     }

--- a/examples/android/build.gradle.kts
+++ b/examples/android/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.connectrpc.examples.android"
         minSdk = 28
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
         multiDexEnabled = true

--- a/extensions/google-java/build.gradle.kts
+++ b/extensions/google-java/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     kotlin("jvm")

--- a/extensions/google-java/build.gradle.kts
+++ b/extensions/google-java/build.gradle.kts
@@ -29,9 +29,9 @@ dependencies {
     implementation(libs.kotlin.reflect)
 }
 
-configure<MavenPublishBaseExtension> {
+mavenPublishing {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
+        KotlinJvm(javadocJar = Dokka("dokkaHtml")),
     )
 }
 

--- a/extensions/google-javalite/build.gradle.kts
+++ b/extensions/google-javalite/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     kotlin("jvm")

--- a/extensions/google-javalite/build.gradle.kts
+++ b/extensions/google-javalite/build.gradle.kts
@@ -28,9 +28,9 @@ sourceSets {
     }
 }
 
-configure<MavenPublishBaseExtension> {
+mavenPublishing {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
+        KotlinJvm(javadocJar = Dokka("dokkaHtml")),
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,17 +6,17 @@ dokka = "1.9.0"
 junit = "4.13.2"
 kotlin = "1.9.10"
 kotlinpoet = "1.14.2"
-mavenplugin = "0.24.0"
+mavenplugin = "0.25.3"
 moshi = "1.15.0"
 okhttp = "4.11.0"
 okio = "3.6.0"
 protobuf = "3.24.4"
 slf4j = "2.0.9"
-spotless = "6.21.0"
+spotless = "6.22.0"
 
 [libraries]
 android = { module = "com.google.android:android", version.ref = "android" }
-android-material = { module = "com.google.android.material:material", version = "1.9.0" }
+android-material = { module = "com.google.android.material:material", version = "1.10.0" }
 android-multidex = { module = "com.android.support:multidex", version = "1.0.3" }
 android-plugin = { module = "com.android.tools.build:gradle", version = "8.1.2" }
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.7.0" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     kotlin("jvm")
@@ -23,11 +22,12 @@ dependencies {
     ksp(libs.moshiKotlinCodegen)
 }
 
-configure<MavenPublishBaseExtension> {
+mavenPublishing {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
+        KotlinJvm(javadocJar = Dokka("dokkaHtml")),
     )
 }
+
 // Workaround for overriding the published library name to "connect-kotlin".
 // Otherwise, the plugin will take the library name.
 extensions.getByType<PublishingExtension>().apply {

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     kotlin("jvm")

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
     api(project(":library"))
 }
 
-configure<MavenPublishBaseExtension> {
+mavenPublishing {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
+        KotlinJvm(javadocJar = Dokka("dokkaHtml")),
     )
 }
 

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     application

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -45,9 +45,9 @@ sourceSets {
     }
 }
 
-configure<MavenPublishBaseExtension> {
+mavenPublishing {
     configure(
-        KotlinJvm(javadocJar = Dokka("dokkaGfm")),
+        KotlinJvm(javadocJar = Dokka("dokkaHtml")),
     )
 }
 

--- a/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Parameters.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/com/connectrpc/protocgen/connect/internal/Parameters.kt
@@ -42,7 +42,8 @@ internal fun parse(input: String): Configuration {
     val parameters = parseGeneratorParameter(input)
     return Configuration(
         generateCallbackMethods = parameters[CALLBACK_SIGNATURE]?.toBoolean() ?: false,
-        generateCoroutineMethods = parameters[COROUTINE_SIGNATURE]?.toBoolean() ?: true, // Defaulted to true.
+        // Defaulted to true.
+        generateCoroutineMethods = parameters[COROUTINE_SIGNATURE]?.toBoolean() ?: true,
         generateBlockingUnaryMethods = parameters[BLOCKING_UNARY_SIGNATURE]?.toBoolean() ?: false,
     )
 }


### PR DESCRIPTION
Update to the latest versions of spotless, android libraries, and the Maven plugin. Fix javadoc generation for Maven artifacts (previously empty).

Fixes #94.
