### PR TITLE
Improve API for bidi and server streaming calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,13 @@ $(PROTOC):
 
 .PHONY: generate
 generate: $(PROTOC) buildplugin generateconformance generateexamples ## Generate proto files for the entire project.
-	buf generate --template protoc-gen-connect-kotlin/buf.gen.yaml -o protoc-gen-connect-kotlin
+	buf generate --template protoc-gen-connect-kotlin/buf.gen.yaml -o protoc-gen-connect-kotlin protoc-gen-connect-kotlin/proto
 	buf generate --template extensions/buf.gen.yaml -o extensions buf.build/googleapis/googleapis
 	make licenseheaders
 
 .PHONY: generateconformance
 generateconformance: $(PROTOC) buildplugin ## Generate protofiles for conformance tests.
-	buf generate --template conformance/buf.gen.yaml -o conformance
+	buf generate --template conformance/buf.gen.yaml -o conformance conformance/proto
 
 .PHONY: generateexamples
 generateexamples: $(PROTOC) buildplugin ## Generate proto files for example apps.

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/Conformance.kt
@@ -240,9 +240,7 @@ class Conformance(
                     assertThat(responses.map { it.payload.body.size() }).isEqualTo(sizes)
                     assertThat(e.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
                     assertThat(e.message).isEqualTo("soirée 🎉")
-                    assertThat(e.unpackedDetails(ErrorDetail::class)).containsExactly(
-                        expectedErrorDetail,
-                    )
+                    assertThat(e.unpackedDetails(ErrorDetail::class)).containsExactly(expectedErrorDetail)
                 } finally {
                     countDownLatch.countDown()
                 }

--- a/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
+++ b/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
@@ -147,7 +147,6 @@ class ElizaChatActivity : AppCompatActivity() {
                         adapter.add(MessageData("...No response from Eliza...", true))
                     }
                 }
-                // This should only be called once.
                 adapter.add(
                     MessageData(
                         "Session has ended.",

--- a/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
+++ b/examples/android/src/main/kotlin/com/connectrpc/examples/android/ElizaChatActivity.kt
@@ -21,6 +21,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
+import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ConverseRequest
 import com.connectrpc.eliza.v1.ElizaServiceClient
@@ -135,29 +136,26 @@ class ElizaChatActivity : AppCompatActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             // Initialize a bidi stream with Eliza.
             val stream = elizaServiceClient.converse()
-
-            for (streamResult in stream.resultChannel()) {
-                streamResult.maybeFold(
-                    onMessage = { result ->
-                        // A stream message is received: Eliza has said something to us.
-                        val elizaResponse = result.message.sentence
-                        if (elizaResponse?.isNotBlank() == true) {
-                            adapter.add(MessageData(elizaResponse, true))
-                        } else {
-                            // Something odd occurred.
-                            adapter.add(MessageData("...No response from Eliza...", true))
-                        }
-                    },
-                    onCompletion = {
-                        // This should only be called once.
-                        adapter.add(
-                            MessageData(
-                                "Session has ended.",
-                                true,
-                            ),
-                        )
-                    },
+            try {
+                for (message in stream.responseChannel()) {
+                    // A stream message is received: Eliza has said something to us.
+                    val elizaResponse = message.sentence
+                    if (elizaResponse?.isNotBlank() == true) {
+                        adapter.add(MessageData(elizaResponse, true))
+                    } else {
+                        // Something odd occurred.
+                        adapter.add(MessageData("...No response from Eliza...", true))
+                    }
+                }
+                // This should only be called once.
+                adapter.add(
+                    MessageData(
+                        "Session has ended.",
+                        true,
+                    ),
                 )
+            } catch (e: ConnectException) {
+                adapter.add(MessageData("Session failed with code ${e.code}", true))
             }
             lifecycleScope.launch(Dispatchers.Main) {
                 buttonView.setOnClickListener {

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -14,7 +14,6 @@
 
 package com.connectrpc.examples.kotlin
 
-import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ElizaServiceClient
 import com.connectrpc.eliza.v1.converseRequest

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -14,7 +14,6 @@
 
 package com.connectrpc.examples.kotlin
 
-import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ElizaServiceClient
@@ -63,23 +62,13 @@ class Main {
                 // Add the message the user is sending to the views.
                 stream.send(converseRequest { sentence = "hello" })
                 stream.sendClose()
-                for (streamResult in stream.resultChannel()) {
-                    streamResult.maybeFold(
-                        onMessage = { result ->
-                            // Update the view with the response.
-                            val elizaResponse = result.message
-                            println(elizaResponse.sentence)
-                        },
-                        onCompletion = { result ->
-                            if (result.code != Code.OK) {
-                                val exception = result.connectException()
-                                if (exception != null) {
-                                    throw exception
-                                }
-                                throw ConnectException(code = result.code, metadata = result.trailers)
-                            }
-                        },
-                    )
+                try {
+                    for (streamResult in stream.responseChannel()) {
+                        // Update the view with the response.
+                        val elizaResponse = streamResult
+                        println(elizaResponse.sentence)
+                    }
+                } catch (e: ConnectException) {
                 }
             }
         }

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -62,13 +62,8 @@ class Main {
                 // Add the message the user is sending to the views.
                 stream.send(converseRequest { sentence = "hello" })
                 stream.sendClose()
-                try {
-                    for (streamResult in stream.responseChannel()) {
-                        // Update the view with the response.
-                        val elizaResponse = streamResult
-                        println(elizaResponse.sentence)
-                    }
-                } catch (e: ConnectException) {
+                for (response in stream.responseChannel()) {
+                    println(response.sentence)
                 }
             }
         }

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -32,7 +32,7 @@ class Main {
         @JvmStatic
         fun main(args: Array<String>) {
             runBlocking {
-                val host = "https://demo.connectrpc.com:444"
+                val host = "https://demo.connectrpc.com"
                 val okHttpClient = OkHttpClient()
                     .newBuilder()
                     .readTimeout(Duration.ofMinutes(10))

--- a/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -14,8 +14,6 @@
 
 package com.connectrpc.examples.kotlin
 
-import com.connectrpc.Code
-import com.connectrpc.ConnectException
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.eliza.v1.ElizaServiceClient
 import com.connectrpc.eliza.v1.converseRequest
@@ -34,7 +32,7 @@ class Main {
         @JvmStatic
         fun main(args: Array<String>) {
             runBlocking {
-                val host = "https://demo.connectrpc.com"
+                val host = "https://demo.connectrpc.com:444"
                 val okHttpClient = OkHttpClient()
                     .newBuilder()
                     .readTimeout(Duration.ofMinutes(10))
@@ -63,23 +61,8 @@ class Main {
                 // Add the message the user is sending to the views.
                 stream.send(converseRequest { sentence = "hello" })
                 stream.sendClose()
-                for (streamResult in stream.resultChannel()) {
-                    streamResult.maybeFold(
-                        onMessage = { result ->
-                            // Update the view with the response.
-                            val elizaResponse = result.message
-                            println(elizaResponse.sentence)
-                        },
-                        onCompletion = { result ->
-                            if (result.code != Code.OK) {
-                                val exception = result.connectException()
-                                if (exception != null) {
-                                    throw exception
-                                }
-                                throw ConnectException(code = result.code, metadata = result.trailers)
-                            }
-                        },
-                    )
+                for (response in stream.responseChannel()) {
+                    println(response.sentence)
                 }
             }
         }

--- a/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
@@ -21,11 +21,11 @@ import kotlinx.coroutines.channels.ReceiveChannel
  */
 interface BidirectionalStreamInterface<Input, Output> {
     /**
-     * The Channel for received StreamResults.
+     * The Channel for responses.
      *
-     * @return ReceiveChannel for iterating over the received results.
+     * @return ReceiveChannel for iterating over the responses.
      */
-    fun resultChannel(): ReceiveChannel<StreamResult<Output>>
+    fun responseChannel(): ReceiveChannel<Output>
 
     /**
      * Send a request to the server over the stream.

--- a/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
@@ -29,9 +29,9 @@ interface ClientOnlyStreamInterface<Input, Output> {
     /**
      * Receive a single response and close the stream.
      *
-     * @return the single response [ResponseMessage].
+     * @return the single response [Output].
      */
-    suspend fun receiveAndClose(): ResponseMessage<Output>
+    suspend fun receiveAndClose(): Output
 
     /**
      * Close the stream. No calls to [send] are valid after calling [sendClose].

--- a/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
@@ -30,6 +30,7 @@ interface ClientOnlyStreamInterface<Input, Output> {
      * Receive a single response and close the stream.
      *
      * @return the single response [Output].
+     * @throws ConnectException If an error occurs making the call or processing the response.
      */
     suspend fun receiveAndClose(): Output
 

--- a/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
@@ -15,6 +15,7 @@
 package com.connectrpc
 
 import kotlinx.coroutines.channels.ReceiveChannel
+
 /**
  * Represents a server-only stream (a stream where the server streams data to the client after
  * receiving an initial request) that can send request messages.
@@ -25,7 +26,7 @@ interface ServerOnlyStreamInterface<Input, Output> {
      *
      * @return ReceiveChannel for iterating over the received results.
      */
-    fun resultChannel(): ReceiveChannel<StreamResult<Output>>
+    fun responseChannel(): ReceiveChannel<Output>
 
     /**
      * Send a request to the server over the stream and closes the request.

--- a/library/src/main/kotlin/com/connectrpc/UnaryBlockingCall.kt
+++ b/library/src/main/kotlin/com/connectrpc/UnaryBlockingCall.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class UnaryBlockingCall<Output> {
     private var executable: ((ResponseMessage<Output>) -> Unit) -> Unit = { }
-    private var cancel: () -> Unit = { }
+    private var cancelFn: () -> Unit = { }
 
     /**
      * Execute the underlying request.
@@ -43,7 +43,7 @@ class UnaryBlockingCall<Output> {
      * Cancel the underlying request.
      */
     fun cancel() {
-        cancel()
+        cancelFn()
     }
 
     /**
@@ -54,7 +54,7 @@ class UnaryBlockingCall<Output> {
      * underlying request.
      */
     internal fun setCancel(cancel: () -> Unit) {
-        this.cancel = cancel
+        this.cancelFn = cancel
     }
 
     /**

--- a/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
@@ -16,7 +16,6 @@ package com.connectrpc.impl
 
 import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.Codec
-import com.connectrpc.StreamResult
 import com.connectrpc.http.Stream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -28,7 +27,7 @@ import java.lang.Exception
 internal class BidirectionalStream<Input, Output>(
     val stream: Stream,
     private val requestCodec: Codec<Input>,
-    private val receiveChannel: Channel<StreamResult<Output>>,
+    private val receiveChannel: Channel<Output>,
 ) : BidirectionalStreamInterface<Input, Output> {
 
     override suspend fun send(input: Input): Result<Unit> {
@@ -40,7 +39,7 @@ internal class BidirectionalStream<Input, Output>(
         return stream.send(msg)
     }
 
-    override fun resultChannel(): ReceiveChannel<StreamResult<Output>> {
+    override fun responseChannel(): ReceiveChannel<Output> {
         return receiveChannel
     }
 

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -34,7 +34,7 @@ internal class ClientOnlyStream<Input, Output>(
         try {
             messageStream.sendClose()
             val message = resultChannel.receive()
-            val additionalMessage = resultChannel.tryReceive()
+            val additionalMessage = resultChannel.receiveCatching()
             if (additionalMessage.isSuccess) {
                 throw ConnectException(code = Code.UNKNOWN, message = "unary stream has multiple messages")
             }

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -18,8 +18,6 @@ import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.ClientOnlyStreamInterface
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
-import com.connectrpc.Headers
-import com.connectrpc.ResponseMessage
 
 /**
  * Concrete implementation of [ClientOnlyStreamInterface].
@@ -31,59 +29,16 @@ internal class ClientOnlyStream<Input, Output>(
         return messageStream.send(input)
     }
 
-    override suspend fun receiveAndClose(): ResponseMessage<Output> {
-        val resultChannel = messageStream.resultChannel()
+    override suspend fun receiveAndClose(): Output {
+        val resultChannel = messageStream.responseChannel()
         try {
             messageStream.sendClose()
-            // TODO: Improve this API for consumers.
-            // We should aim to provide ease of use for callers so they don't need to individually examine each result
-            // in the channel (headers, 1* messages, completion) and have to resort to fold()/maybeFold() to interpret
-            // the overall results.
-            // Additionally, ResponseMessage.Success and ResponseMessage.Failure shouldn't be necessary for client use.
-            // We should throw ConnectException for failure and only have users have to deal with success messages.
-            var headers: Headers = emptyMap()
-            var message: Output? = null
-            var trailers: Headers = emptyMap()
-            var code: Code? = null
-            var error: ConnectException? = null
-            for (result in resultChannel) {
-                result.maybeFold(
-                    onHeaders = {
-                        headers = it.headers
-                    },
-                    onMessage = {
-                        message = it.message
-                    },
-                    onCompletion = {
-                        code = it.code
-                        trailers = it.trailers
-                        val resultErr = it.cause
-                        if (resultErr != null) {
-                            error = if (resultErr is ConnectException) {
-                                resultErr
-                            } else {
-                                ConnectException(code ?: Code.UNKNOWN, message = error?.message, exception = error, metadata = trailers)
-                            }
-                        }
-                    },
-                )
+            val message = resultChannel.receive()
+            val additionalMessage = resultChannel.tryReceive()
+            if (additionalMessage.isSuccess) {
+                throw ConnectException(code = Code.UNKNOWN, message = "unary stream has multiple messages")
             }
-            if (error != null) {
-                return ResponseMessage.Failure(error!!, code ?: Code.UNKNOWN, headers, trailers)
-            }
-            if (code == null) {
-                return ResponseMessage.Failure(ConnectException(Code.UNKNOWN, message = "unknown status code"), Code.UNKNOWN, headers, trailers)
-            }
-            if (message != null) {
-                return ResponseMessage.Success(message!!, code!!, headers, trailers)
-            }
-            // We didn't receive an error at any point, however we didn't get a response message either.
-            return ResponseMessage.Failure(
-                ConnectException(Code.UNKNOWN, message = "missing response message"),
-                code!!,
-                headers,
-                trailers,
-            )
+            return message
         } finally {
             resultChannel.cancel()
         }

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -196,17 +196,17 @@ class ProtocolClient(
                         )
                         channel.send(message)
                     } catch (e: Throwable) {
-                        channel.close(ConnectException(Code.UNKNOWN, exception = e))
                         isComplete = true
+                        channel.close(ConnectException(Code.UNKNOWN, exception = e))
                     }
                 }
 
                 is StreamResult.Complete -> {
+                    isComplete = true
                     when (streamResult.code) {
                         Code.OK -> channel.close()
                         else -> channel.close(streamResult.connectException() ?: ConnectException(code = streamResult.code))
                     }
-                    isComplete = true
                 }
             }
         }

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -17,6 +17,7 @@ package com.connectrpc.impl
 import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.ClientOnlyStreamInterface
 import com.connectrpc.Code
+import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.MethodSpec
 import com.connectrpc.ProtocolClientConfig
@@ -149,7 +150,7 @@ class ProtocolClient(
         headers: Headers,
         methodSpec: MethodSpec<Input, Output>,
     ): ServerOnlyStreamInterface<Input, Output> {
-        val stream = stream(headers, methodSpec)
+        val stream = bidirectionalStream(methodSpec, headers)
         return ServerOnlyStream(stream)
     }
 
@@ -164,8 +165,8 @@ class ProtocolClient(
     private suspend fun <Input : Any, Output : Any> bidirectionalStream(
         methodSpec: MethodSpec<Input, Output>,
         headers: Headers,
-    ): BidirectionalStreamInterface<Input, Output> = suspendCancellableCoroutine { continuation ->
-        val channel = Channel<StreamResult<Output>>(1)
+    ): BidirectionalStream<Input, Output> = suspendCancellableCoroutine { continuation ->
+        val channel = Channel<Output>(1)
         val requestCodec = config.serializationStrategy.codec(methodSpec.requestClass)
         val responseCodec = config.serializationStrategy.codec(methodSpec.responseClass)
         val request = HTTPRequest(
@@ -183,10 +184,9 @@ class ProtocolClient(
                 return@stream
             }
             // Pass through the interceptor chain.
-            val streamResult = streamFunc.streamResultFunction(initialResult)
-            val result: StreamResult<Output> = when (streamResult) {
+            when (val streamResult = streamFunc.streamResultFunction(initialResult)) {
                 is StreamResult.Headers -> {
-                    StreamResult.Headers(streamResult.headers)
+                    // Not currently used except for interceptors.
                 }
 
                 is StreamResult.Message -> {
@@ -194,25 +194,20 @@ class ProtocolClient(
                         val message = responseCodec.deserialize(
                             streamResult.message,
                         )
-                        StreamResult.Message(message)
+                        channel.send(message)
                     } catch (e: Throwable) {
+                        channel.close(ConnectException(Code.UNKNOWN, exception = e))
                         isComplete = true
-                        StreamResult.Complete(Code.UNKNOWN, e)
                     }
                 }
 
                 is StreamResult.Complete -> {
+                    when (streamResult.code) {
+                        Code.OK -> channel.close()
+                        else -> channel.close(streamResult.connectException() ?: ConnectException(code = streamResult.code))
+                    }
                     isComplete = true
-                    StreamResult.Complete(
-                        streamResult.connectException()?.code ?: Code.OK,
-                        cause = streamResult.cause,
-                        trailers = streamResult.trailers,
-                    )
                 }
-            }
-            channel.send(result)
-            if (isComplete) {
-                channel.close()
             }
         }
         continuation.invokeOnCancellation {

--- a/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
@@ -16,7 +16,6 @@ package com.connectrpc.impl
 
 import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.ServerOnlyStreamInterface
-import com.connectrpc.StreamResult
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
@@ -25,8 +24,8 @@ import kotlinx.coroutines.channels.ReceiveChannel
 internal class ServerOnlyStream<Input, Output>(
     private val messageStream: BidirectionalStreamInterface<Input, Output>,
 ) : ServerOnlyStreamInterface<Input, Output> {
-    override fun resultChannel(): ReceiveChannel<StreamResult<Output>> {
-        return messageStream.resultChannel()
+    override fun responseChannel(): ReceiveChannel<Output> {
+        return messageStream.responseChannel()
     }
 
     override suspend fun sendAndClose(input: Input): Result<Unit> {

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
@@ -167,11 +167,7 @@ internal class ConnectInterceptor(
                             StreamResult.Message(unpackedMessage)
                         }
                     },
-                    onCompletion = { result ->
-                        val streamTrailers = result.trailers
-                        val error = result.connectException()
-                        StreamResult.Complete(error?.code ?: Code.OK, cause = error, streamTrailers)
-                    },
+                    onCompletion = { result -> result },
                 )
                 streamResult
             },

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -214,9 +214,7 @@ internal class GRPCWebInterceptor(
                         }
                         StreamResult.Message(unpackedMessage)
                     },
-                    onCompletion = { result ->
-                        result
-                    },
+                    onCompletion = { result -> result },
                 )
                 streamResult
             },


### PR DESCRIPTION
Instead of requiring callers to handle oneOf(Headers,Message,Trailers) objects in each bidi or server streaming call, instead just change the response channel to return the response message type. If an error occurs at the end of the call (due to non-zero grpc-status), then cancel the channel with an exception.
