### PR TITLE
Use a more specific type for error callbacks

### DIFF
--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -89,7 +89,7 @@ fun ResponseMessage<*>.exceptionOrNull(): Throwable? {
  */
 inline fun <R, T> ResponseMessage<T>.fold(
     onSuccess: (value: T) -> R,
-    onFailure: (exception: Throwable) -> R,
+    onFailure: (exception: ConnectException) -> R,
 ): R {
     return when (this) {
         is ResponseMessage.Success -> onSuccess(this.message)
@@ -114,7 +114,7 @@ fun <T> ResponseMessage<T>.getOrDefault(defaultValue: T): T {
  *
  * Note, that this function rethrows any [Throwable] exception thrown by [onFailure] function.
  */
-inline fun <R, T : R> ResponseMessage<T>.getOrElse(onFailure: (exception: Throwable) -> R): R {
+inline fun <R, T : R> ResponseMessage<T>.getOrElse(onFailure: (exception: ConnectException) -> R): R {
     return when (this) {
         is ResponseMessage.Success -> this.message
         is ResponseMessage.Failure -> onFailure(this.cause)


### PR DESCRIPTION
**Before submitting your PR:** Please read through the contribution guide at https://github.com/connectrpc/connect-kotlin/blob/main/.github/CONTRIBUTING.md

Error callbacks are only ever called with `ConnectException` as arguments. Being more specific in these requests can tidy up call-sites in avoiding type assertions (as a hard cast to `ConnectException`) or overly generic handling where callers account for additional exception types that won't ever be used.
