### PR TITLE
Allow building with Java 20 and later versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,9 @@ subprojects {
             jvmTarget = "1.8"
             languageVersion = "1.6"
             apiVersion = "1.6"
+            if (JavaVersion.current().isJava9Compatible && project.name != "android") {
+                freeCompilerArgs += "-Xjdk-release=1.8"
+            }
         }
     }
     tasks.withType<JavaCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ spotless = "6.22.0"
 android = { module = "com.google.android:android", version.ref = "android" }
 android-material = { module = "com.google.android.material:material", version = "1.10.0" }
 android-multidex = { module = "com.android.support:multidex", version = "1.0.3" }
-android-plugin = { module = "com.android.tools.build:gradle", version = "8.1.2" }
+android-plugin = { module = "com.android.tools.build:gradle", version = "8.1.3" }
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.7.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
 androidx-compose = { module = "androidx.activity:activity-compose", version = "1.8.0" }


### PR DESCRIPTION
Update the KotlinCompile args to add `-Xjdk-release=1.8` which is the equivalent of the `--release 8` argument when compiling Java code. This will ensure that we only use APIs which are in Java 1.8 and not added in later versions. This fixes compiler warnings around use of `new URL(String)` which is deprecated starting in Java 20.
