### PR TITLE
Add support for accessing headers and trailers to streaming calls

### DIFF
--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
@@ -56,7 +56,7 @@ class ConformanceTest(
 ) : BaseConformanceTest(protocol, serverType) {
     companion object {
         private val responseHeaders = mapOf(Pair("x-grpc-test-echo-initial", listOf("test_initial_metadata_value")))
-        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL")), /* base64-encoded 0x0a0b0a0b0a0b */)
+        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL"))) // base64-encoded 0x0a0b0a0b0a0b
         private val requestHeaders = responseHeaders + responseTrailers
     }
 

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
@@ -88,7 +88,6 @@ class ConformanceTest(
         }
         assertThat(responses.map { it.payload.type }.toSet()).isEqualTo(setOf(PayloadType.COMPRESSABLE))
         assertThat(responses.map { it.payload.body.size() }).isEqualTo(sizes)
-        assertThat(stream.responseTrailers().isCompleted).isTrue()
         assertThat(stream.responseTrailers().await()).containsAllEntriesOf(responseTrailers)
     }
 
@@ -701,7 +700,6 @@ class ConformanceTest(
                     val response = stream.receiveAndClose()
                     assertThat(response.aggregatedPayloadSize).isEqualTo(sum)
                     assertThat(stream.responseHeaders().isCompleted).isTrue()
-                    assertThat(stream.responseTrailers().isCompleted).isTrue()
                     assertThat(stream.responseHeaders().await()).isNotEmpty()
                     if (protocol != NetworkProtocol.CONNECT) {
                         // gRPC and gRPC-web communicate RPC status in trailers, so

--- a/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
+++ b/conformance/google-java/src/test/kotlin/com/connectrpc/conformance/java/ConformanceTest.kt
@@ -51,9 +51,14 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(Parameterized::class)
 class ConformanceTest(
-    protocol: NetworkProtocol,
+    private val protocol: NetworkProtocol,
     serverType: ServerType,
 ) : BaseConformanceTest(protocol, serverType) {
+    companion object {
+        private val responseHeaders = mapOf(Pair("x-grpc-test-echo-initial", listOf("test_initial_metadata_value")))
+        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL")), /* base64-encoded 0x0a0b0a0b0a0b */)
+        private val requestHeaders = responseHeaders + responseTrailers
+    }
 
     private lateinit var unimplementedServiceClient: UnimplementedServiceClient
     private lateinit var testServiceConnectClient: TestServiceClient
@@ -68,7 +73,7 @@ class ConformanceTest(
     @Test
     fun serverStreaming(): Unit = runBlocking {
         val sizes = listOf(512_000, 16, 2_028, 65_536)
-        val stream = testServiceConnectClient.streamingOutputCall()
+        val stream = testServiceConnectClient.streamingOutputCall(requestHeaders)
         val params = sizes.map { responseParameters { size = it } }.toList()
         stream.sendAndClose(
             streamingOutputCallRequest {
@@ -76,12 +81,15 @@ class ConformanceTest(
                 responseParameters += params
             },
         ).getOrThrow()
+        assertThat(stream.responseHeaders().await()).containsAllEntriesOf(responseHeaders)
         val responses = mutableListOf<StreamingOutputCallResponse>()
         for (response in stream.responseChannel()) {
             responses.add(response)
         }
         assertThat(responses.map { it.payload.type }.toSet()).isEqualTo(setOf(PayloadType.COMPRESSABLE))
         assertThat(responses.map { it.payload.body.size() }).isEqualTo(sizes)
+        assertThat(stream.responseTrailers().isCompleted).isTrue()
+        assertThat(stream.responseTrailers().await()).containsAllEntriesOf(responseTrailers)
     }
 
     @Test
@@ -673,7 +681,7 @@ class ConformanceTest(
 
     @Test
     fun clientStreaming(): Unit = runBlocking {
-        val stream = testServiceConnectClient.streamingInputCall(emptyMap())
+        val stream = testServiceConnectClient.streamingInputCall()
         var sum = 0
         listOf(256000, 8, 1024, 32768).forEach { size ->
             stream.send(
@@ -692,6 +700,14 @@ class ConformanceTest(
                 try {
                     val response = stream.receiveAndClose()
                     assertThat(response.aggregatedPayloadSize).isEqualTo(sum)
+                    assertThat(stream.responseHeaders().isCompleted).isTrue()
+                    assertThat(stream.responseTrailers().isCompleted).isTrue()
+                    assertThat(stream.responseHeaders().await()).isNotEmpty()
+                    if (protocol != NetworkProtocol.CONNECT) {
+                        // gRPC and gRPC-web communicate RPC status in trailers, so
+                        // they should always have something.
+                        assertThat(stream.responseTrailers().await()).isNotEmpty()
+                    }
                 } finally {
                     countDownLatch.countDown()
                 }

--- a/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
+++ b/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
@@ -56,7 +56,7 @@ class ConformanceTest(
 ) : BaseConformanceTest(protocol, serverType) {
     companion object {
         private val responseHeaders = mapOf(Pair("x-grpc-test-echo-initial", listOf("test_initial_metadata_value")))
-        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL")), /* base64-encoded 0x0a0b0a0b0a0b */)
+        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL"))) // base64-encoded 0x0a0b0a0b0a0b
         private val requestHeaders = responseHeaders + responseTrailers
     }
 

--- a/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
+++ b/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
@@ -88,7 +88,6 @@ class ConformanceTest(
         }
         assertThat(responses.map { it.payload.type }.toSet()).isEqualTo(setOf(PayloadType.COMPRESSABLE))
         assertThat(responses.map { it.payload.body.size() }).isEqualTo(sizes)
-        assertThat(stream.responseTrailers().isCompleted).isTrue()
         assertThat(stream.responseTrailers().await()).containsAllEntriesOf(responseTrailers)
     }
 
@@ -701,7 +700,6 @@ class ConformanceTest(
                     val response = stream.receiveAndClose()
                     assertThat(response.aggregatedPayloadSize).isEqualTo(sum)
                     assertThat(stream.responseHeaders().isCompleted).isTrue()
-                    assertThat(stream.responseTrailers().isCompleted).isTrue()
                     assertThat(stream.responseHeaders().await()).isNotEmpty()
                     if (protocol != NetworkProtocol.CONNECT) {
                         // gRPC and gRPC-web communicate RPC status in trailers, so

--- a/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
+++ b/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
@@ -51,9 +51,14 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(Parameterized::class)
 class ConformanceTest(
-    protocol: NetworkProtocol,
+    private val protocol: NetworkProtocol,
     serverType: ServerType,
 ) : BaseConformanceTest(protocol, serverType) {
+    companion object {
+        private val responseHeaders = mapOf(Pair("x-grpc-test-echo-initial", listOf("test_initial_metadata_value")))
+        private val responseTrailers = mapOf(Pair("x-grpc-test-echo-trailing-bin", listOf("CgsKCwoL")), /* base64-encoded 0x0a0b0a0b0a0b */)
+        private val requestHeaders = responseHeaders + responseTrailers
+    }
 
     private lateinit var unimplementedServiceClient: UnimplementedServiceClient
     private lateinit var testServiceConnectClient: TestServiceClient
@@ -68,7 +73,7 @@ class ConformanceTest(
     @Test
     fun serverStreaming(): Unit = runBlocking {
         val sizes = listOf(512_000, 16, 2_028, 65_536)
-        val stream = testServiceConnectClient.streamingOutputCall()
+        val stream = testServiceConnectClient.streamingOutputCall(requestHeaders)
         val params = sizes.map { responseParameters { size = it } }.toList()
         stream.sendAndClose(
             streamingOutputCallRequest {
@@ -76,12 +81,15 @@ class ConformanceTest(
                 responseParameters += params
             },
         ).getOrThrow()
+        assertThat(stream.responseHeaders().await()).containsAllEntriesOf(responseHeaders)
         val responses = mutableListOf<StreamingOutputCallResponse>()
         for (response in stream.responseChannel()) {
             responses.add(response)
         }
         assertThat(responses.map { it.payload.type }.toSet()).isEqualTo(setOf(PayloadType.COMPRESSABLE))
         assertThat(responses.map { it.payload.body.size() }).isEqualTo(sizes)
+        assertThat(stream.responseTrailers().isCompleted).isTrue()
+        assertThat(stream.responseTrailers().await()).containsAllEntriesOf(responseTrailers)
     }
 
     @Test
@@ -673,7 +681,7 @@ class ConformanceTest(
 
     @Test
     fun clientStreaming(): Unit = runBlocking {
-        val stream = testServiceConnectClient.streamingInputCall(emptyMap())
+        val stream = testServiceConnectClient.streamingInputCall()
         var sum = 0
         listOf(256000, 8, 1024, 32768).forEach { size ->
             stream.send(
@@ -692,6 +700,14 @@ class ConformanceTest(
                 try {
                     val response = stream.receiveAndClose()
                     assertThat(response.aggregatedPayloadSize).isEqualTo(sum)
+                    assertThat(stream.responseHeaders().isCompleted).isTrue()
+                    assertThat(stream.responseTrailers().isCompleted).isTrue()
+                    assertThat(stream.responseHeaders().await()).isNotEmpty()
+                    if (protocol != NetworkProtocol.CONNECT) {
+                        // gRPC and gRPC-web communicate RPC status in trailers, so
+                        // they should always have something.
+                        assertThat(stream.responseTrailers().await()).isNotEmpty()
+                    }
                 } finally {
                     countDownLatch.countDown()
                 }

--- a/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc
 
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
@@ -26,6 +27,25 @@ interface BidirectionalStreamInterface<Input, Output> {
      * @return ReceiveChannel for iterating over the responses.
      */
     fun responseChannel(): ReceiveChannel<Output>
+
+    /**
+     * The response headers. This value will become available before any output
+     * messages become available from the [responseChannel] and before trailers
+     * are available from [responseTrailers]. If the stream fails before headers
+     * are ever received, this will complete with an empty value. The
+     * [ReceiveChannel.receive] method of [responseChannel] can be used to
+     * recover the exception that caused such a failure.
+     */
+    fun responseHeaders(): Deferred<Headers>
+
+    /**
+     * The response trailers. This value will not become available until the entire
+     * RPC operation is complete. If the stream fails before trailers are ever
+     * received, this will complete with an empty value. The [ReceiveChannel.receive]
+     * method of [responseChannel] can be used to recover the exception that caused
+     * such a failure.
+     */
+    fun responseTrailers(): Deferred<Headers>
 
     /**
      * Send a request to the server over the stream.

--- a/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
@@ -14,6 +14,8 @@
 
 package com.connectrpc
 
+import kotlinx.coroutines.Deferred
+
 /**
  * Represents a client-only stream (a stream where the client streams data to the server and
  * eventually receives a response) that can send request messages and initiate closes.
@@ -33,6 +35,24 @@ interface ClientOnlyStreamInterface<Input, Output> {
      * @throws ConnectException If an error occurs making the call or processing the response.
      */
     suspend fun receiveAndClose(): Output
+
+    /**
+     * The response headers. This value will become available before any call to
+     * [receiveAndClose] completes and before trailers are available from
+     * [responseTrailers] (though these may occur nearly simultaneously). If the
+     * stream fails before headers are ever received, this will complete with an
+     * empty value. The [receiveAndClose] method can be used to recover the
+     * exception that caused such a failure.
+     */
+    fun responseHeaders(): Deferred<Headers>
+
+    /**
+     * The response trailers. This value will not become available until the entire
+     * RPC operation is complete. If the stream fails before trailers are ever
+     * received, this will complete with an empty value. The [receiveAndClose]
+     * method can be used to recover the exception that caused such a failure.
+     */
+    fun responseTrailers(): Deferred<Headers>
 
     /**
      * Close the stream. No calls to [send] are valid after calling [sendClose].

--- a/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc
 
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
@@ -27,6 +28,25 @@ interface ServerOnlyStreamInterface<Input, Output> {
      * @return ReceiveChannel for iterating over the received results.
      */
     fun responseChannel(): ReceiveChannel<Output>
+
+    /**
+     * The response headers. This value will become available before any output
+     * messages become available from the [responseChannel] and before trailers
+     * are available from [responseTrailers]. If the stream fails before headers
+     * are ever received, this will complete with an empty value. The
+     * [ReceiveChannel.receive] method of [responseChannel] can be used to
+     * recover the exception that caused such a failure.
+     */
+    fun responseHeaders(): Deferred<Headers>
+
+    /**
+     * The response trailers. This value will not become available until the entire
+     * RPC operation is complete. If the stream fails before trailers are ever
+     * received, this will complete with an empty value. The [ReceiveChannel.receive]
+     * method of [responseChannel] can be used to recover the exception that caused
+     * such a failure.
+     */
+    fun responseTrailers(): Deferred<Headers>
 
     /**
      * Send a request to the server over the stream and closes the request.

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -56,7 +56,7 @@ class Stream(
     private val isReceiveClosed = AtomicReference(false)
 
     fun send(buffer: Buffer): Result<Unit> {
-        if (isClosed()) {
+        if (isSendClosed()) {
             return Result.failure(IllegalStateException("cannot send. underlying stream is closed"))
         }
         return try {
@@ -76,11 +76,14 @@ class Stream(
     fun receiveClose() {
         if (!isReceiveClosed.getAndSet(true)) {
             onReceiveClose()
+            // closing receive side implicitly closes send side, too
+            isSendClosed.set(true)
         }
     }
 
+    // TODO: remove this method as it is redundant with receive closed
     fun isClosed(): Boolean {
-        return isSendClosed() && isReceiveClosed()
+        return isReceiveClosed()
     }
 
     fun isSendClosed(): Boolean {

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -75,9 +75,17 @@ class Stream(
 
     fun receiveClose() {
         if (!isReceiveClosed.getAndSet(true)) {
-            onReceiveClose()
-            // closing receive side implicitly closes send side, too
-            isSendClosed.set(true)
+            try {
+                onReceiveClose()
+            } finally {
+                // When receive side is closed, the send side is
+                // implicitly closed as well.
+                // We don't use sendClose() because we don't want to
+                // invoke onSendClose() since that will try to actually
+                // half-close the HTTP stream, which will fail since the
+                // closing the receive side cancels the entire thing.
+                isSendClosed.set(true)
+            }
         }
     }
 

--- a/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
@@ -16,7 +16,9 @@ package com.connectrpc.impl
 
 import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.Codec
+import com.connectrpc.Headers
 import com.connectrpc.http.Stream
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import java.lang.Exception
@@ -27,7 +29,9 @@ import java.lang.Exception
 internal class BidirectionalStream<Input, Output>(
     val stream: Stream,
     private val requestCodec: Codec<Input>,
-    private val receiveChannel: Channel<Output>,
+    private val responseChannel: Channel<Output>,
+    private val responseHeaders: Deferred<Headers>,
+    private val responseTrailers: Deferred<Headers>,
 ) : BidirectionalStreamInterface<Input, Output> {
 
     override suspend fun send(input: Input): Result<Unit> {
@@ -40,7 +44,15 @@ internal class BidirectionalStream<Input, Output>(
     }
 
     override fun responseChannel(): ReceiveChannel<Output> {
-        return receiveChannel
+        return responseChannel
+    }
+
+    override fun responseHeaders(): Deferred<Headers> {
+        return responseHeaders
+    }
+
+    override fun responseTrailers(): Deferred<Headers> {
+        return responseTrailers
     }
 
     override fun isClosed(): Boolean {

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -18,6 +18,8 @@ import com.connectrpc.BidirectionalStreamInterface
 import com.connectrpc.ClientOnlyStreamInterface
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
+import com.connectrpc.Headers
+import kotlinx.coroutines.Deferred
 
 /**
  * Concrete implementation of [ClientOnlyStreamInterface].
@@ -42,6 +44,14 @@ internal class ClientOnlyStream<Input, Output>(
         } finally {
             resultChannel.cancel()
         }
+    }
+
+    override fun responseHeaders(): Deferred<Headers> {
+        return messageStream.responseHeaders()
+    }
+
+    override fun responseTrailers(): Deferred<Headers> {
+        return messageStream.responseTrailers()
     }
 
     override fun sendClose() {

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -216,10 +216,6 @@ class ProtocolClient(
                         )
                         channel.send(message)
                     } catch (e: Throwable) {
-                        // TODO: setting isComplete, responseTrailers, and RPC status
-                        //       here seems wrong. What would prevent the call to
-                        //       channel.send such that we don't bother getting the
-                        //       actual result/trailers from the server?
                         isComplete = true
                         try {
                             channel.close(ConnectException(Code.UNKNOWN, exception = e))

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -31,6 +31,7 @@ import com.connectrpc.http.HTTPClientInterface
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.Stream
 import com.connectrpc.protocols.GETConfiguration
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.net.URL
@@ -178,6 +179,8 @@ class ProtocolClient(
         headers: Headers,
     ): BidirectionalStream<Input, Output> = suspendCancellableCoroutine { continuation ->
         val channel = Channel<Output>(1)
+        val responseHeaders = CompletableDeferred<Headers>()
+        val responseTrailers = CompletableDeferred<Headers>()
         val requestCodec = config.serializationStrategy.codec(methodSpec.requestClass)
         val responseCodec = config.serializationStrategy.codec(methodSpec.responseClass)
         val request = HTTPRequest(
@@ -197,32 +200,51 @@ class ProtocolClient(
             // Pass through the interceptor chain.
             when (val streamResult = streamFunc.streamResultFunction(initialResult)) {
                 is StreamResult.Headers -> {
-                    // Not currently used except for interceptors.
+                    // If this is incorrectly called 2x, only the first result is used.
+                    // Subsequent calls to complete will be ignored.
+                    responseHeaders.complete(streamResult.headers)
                 }
 
                 is StreamResult.Message -> {
+                    // Just in case protocol impl failed to provide StreamResult.Headers,
+                    // treat headers as empty. This is a no-op if we did correctly receive
+                    // them already.
+                    responseHeaders.complete(emptyMap())
                     try {
                         val message = responseCodec.deserialize(
                             streamResult.message,
                         )
                         channel.send(message)
                     } catch (e: Throwable) {
+                        // TODO: setting isComplete, responseTrailers, and RPC status
+                        //       here seems wrong. What would prevent the call to
+                        //       channel.send such that we don't bother getting the
+                        //       actual result/trailers from the server?
                         isComplete = true
-                        channel.close(ConnectException(Code.UNKNOWN, exception = e))
+                        try {
+                            channel.close(ConnectException(Code.UNKNOWN, exception = e))
+                        } finally {
+                            responseTrailers.complete(emptyMap())
+                        }
                     }
                 }
 
                 is StreamResult.Complete -> {
+                    // This is a no-op if we already received a StreamResult.Headers.
+                    responseHeaders.complete(emptyMap())
                     isComplete = true
-                    when (streamResult.code) {
-                        Code.OK -> channel.close()
-                        else -> channel.close(streamResult.connectException() ?: ConnectException(code = streamResult.code))
+                    try {
+                        when (streamResult.code) {
+                            Code.OK -> channel.close()
+                            else -> channel.close(streamResult.connectException() ?: ConnectException(code = streamResult.code))
+                        }
+                    } finally {
+                        responseTrailers.complete(streamResult.trailers)
                     }
                 }
             }
         }
         continuation.invokeOnCancellation {
-            httpStream.sendClose()
             httpStream.receiveClose()
         }
         val stream = Stream(
@@ -237,7 +259,6 @@ class ProtocolClient(
             },
         )
         channel.invokeOnClose {
-            // Receive channel is closed so the stream's receive will be closed.
             stream.receiveClose()
         }
         continuation.resume(
@@ -245,6 +266,8 @@ class ProtocolClient(
                 stream,
                 requestCodec,
                 channel,
+                responseHeaders,
+                responseTrailers,
             ),
         )
     }

--- a/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
@@ -15,7 +15,9 @@
 package com.connectrpc.impl
 
 import com.connectrpc.BidirectionalStreamInterface
+import com.connectrpc.Headers
 import com.connectrpc.ServerOnlyStreamInterface
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
@@ -26,6 +28,14 @@ internal class ServerOnlyStream<Input, Output>(
 ) : ServerOnlyStreamInterface<Input, Output> {
     override fun responseChannel(): ReceiveChannel<Output> {
         return messageStream.responseChannel()
+    }
+
+    override fun responseHeaders(): Deferred<Headers> {
+        return messageStream.responseHeaders()
+    }
+
+    override fun responseTrailers(): Deferred<Headers> {
+        return messageStream.responseTrailers()
     }
 
     override suspend fun sendAndClose(input: Input): Result<Unit> {

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -76,6 +76,8 @@ internal fun OkHttpClient.initializeStream(
         onReceiveClose = {
             isReceiveClosed.set(true)
             call.cancel()
+            // cancelling implicitly closes send-side, too
+            isSendClosed.set(true)
         },
     )
 }


### PR DESCRIPTION
This is done via a `CompletableDeferred` which is completed when the headers/trailers are received.