### PR TITLE
Adds new conformance/client module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ generate: $(PROTOC) buildplugin generateconformance generateexamples ## Generate
 .PHONY: generateconformance
 generateconformance: $(PROTOC) buildplugin ## Generate protofiles for conformance tests.
 	buf generate --template conformance/buf.gen.yaml -o conformance conformance/proto
+	buf generate --template conformance/client/buf.gen.yaml -o conformance/client buf.build/connectrpc/conformance:v1.0.0-rc1
+	buf generate --template conformance/client/buf.gen.lite.yaml -o conformance/client buf.build/connectrpc/conformance:v1.0.0-rc1
 
 .PHONY: generateexamples
 generateexamples: $(PROTOC) buildplugin ## Generate proto files for example apps.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BIN := .tmp/bin
 CACHE := .tmp/cache
 LICENSE_HEADER_YEAR_RANGE := 2022-2023
 LICENSE_HEADER_VERSION := v1.28.1
+CONFORMANCE_VERSION := v1.0.0-rc1
 PROTOC_VERSION ?= 25.1
 GRADLE_ARGS ?=
 
@@ -74,8 +75,8 @@ generate: $(PROTOC) buildplugin generateconformance generateexamples ## Generate
 .PHONY: generateconformance
 generateconformance: $(PROTOC) buildplugin ## Generate protofiles for conformance tests.
 	buf generate --template conformance/buf.gen.yaml -o conformance conformance/proto
-	buf generate --template conformance/client/buf.gen.yaml -o conformance/client buf.build/connectrpc/conformance:v1.0.0-rc1
-	buf generate --template conformance/client/buf.gen.lite.yaml -o conformance/client buf.build/connectrpc/conformance:v1.0.0-rc1
+	buf generate --template conformance/client/buf.gen.yaml -o conformance/client buf.build/connectrpc/conformance:$(CONFORMANCE_VERSION)
+	buf generate --template conformance/client/buf.gen.lite.yaml -o conformance/client buf.build/connectrpc/conformance:$(CONFORMANCE_VERSION)
 
 .PHONY: generateexamples
 generateexamples: $(PROTOC) buildplugin ## Generate proto files for example apps.

--- a/conformance/client/buf.gen.lite.yaml
+++ b/conformance/client/buf.gen.lite.yaml
@@ -1,0 +1,20 @@
+version: v1
+managed:
+  enabled: true
+  java_package_prefix: com.connectrpc.lite
+plugins:
+  - plugin: connect-kotlin
+    out: build/generated/sources/bufgen
+    path: ./protoc-gen-connect-kotlin/build/install/protoc-gen-connect-kotlin/bin/protoc-gen-connect-kotlin
+    opt:
+      - generateCallbackMethods=true
+      - generateCoroutineMethods=true
+      - generateBlockingUnaryMethods=true
+  - plugin: java
+    out: build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+    opt: lite
+  - plugin: kotlin
+    out: build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+    opt: lite

--- a/conformance/client/buf.gen.yaml
+++ b/conformance/client/buf.gen.yaml
@@ -1,0 +1,17 @@
+version: v1
+managed:
+  enabled: true
+plugins:
+  - plugin: connect-kotlin
+    out: google-java/build/generated/sources/bufgen
+    path: ./protoc-gen-connect-kotlin/build/install/protoc-gen-connect-kotlin/bin/protoc-gen-connect-kotlin
+    opt:
+      - generateCallbackMethods=true
+      - generateCoroutineMethods=true
+      - generateBlockingUnaryMethods=true
+  - plugin: java
+    out: google-java/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+  - plugin: kotlin
+    out: google-java/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc

--- a/conformance/client/build.gradle.kts
+++ b/conformance/client/build.gradle.kts
@@ -32,7 +32,7 @@ tasks {
 dependencies {
     implementation(project(":okhttp"))
     implementation(libs.kotlin.coroutines.core)
-    implementation(libs.protobuf.kotlin)
+    implementation(libs.protobuf.kotlinlite)
     implementation(libs.protobuf.javalite)
     implementation(libs.okio.core)
     implementation(libs.okhttp.tls)

--- a/conformance/client/build.gradle.kts
+++ b/conformance/client/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    kotlin("jvm")
+}
+
+// This base project contains generated code for the lite runtime
+// and depends on the Google Protobuf Java Lite runtime.
+// The main client logic is implemented in terms of generated
+// code for that lite runtime.
+//
+// The non-lite runtime excludes the Google Protobuf Java Lite
+// runtime and instead uses the full Java runtime. It then can
+// adapt from the lite-runtime-generated code by serializing to
+// bytes and then de-serializing into non-lite-generated types.
+
+sourceSets {
+    main {
+        java {
+            srcDir("build/generated/sources/bufgen")
+        }
+    }
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            // Generated Kotlin code for protobufs uses RequiresOptIn annotation
+            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":okhttp"))
+    implementation(libs.kotlin.coroutines.core)
+    implementation(libs.protobuf.kotlin)
+    implementation(libs.protobuf.javalite)
+    implementation(libs.okio.core)
+    implementation(libs.okhttp.tls)
+}

--- a/conformance/client/google-java/build.gradle.kts
+++ b/conformance/client/google-java/build.gradle.kts
@@ -4,13 +4,13 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
+        classpath(libs.shadowjar)
     }
 }
 
 plugins {
     kotlin("jvm")
-    id("com.github.johnrengelman.shadow").version("7.1.2")
+    alias(libs.plugins.shadowjar)
 }
 
 tasks {
@@ -44,6 +44,7 @@ sourceSets {
 dependencies {
     implementation(project(":conformance:client")) {
         exclude(group = "com.google.protobuf", module = "protobuf-javalite")
+        exclude(group = "com.google.protobuf", module = "protobuf-kotlinlite")
     }
     implementation(project(":extensions:google-java"))
     implementation(project(":okhttp"))

--- a/conformance/client/google-java/build.gradle.kts
+++ b/conformance/client/google-java/build.gradle.kts
@@ -1,0 +1,55 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
+    }
+}
+
+plugins {
+    kotlin("jvm")
+    id("com.github.johnrengelman.shadow").version("7.1.2")
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            // Generated Kotlin code for protobufs uses OptIn annotation
+            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        }
+    }
+    shadowJar {
+        archiveBaseName.set("shadow")
+        manifest {
+            attributes(mapOf("Main-Class" to "com.connectrpc.conformance.client.java.MainKt"))
+        }
+    }
+    build {
+        dependsOn(shadowJar)
+    }
+}
+
+// This project contains an alternate copy of the generated
+// types, generated for the non-lite runtime.
+sourceSets {
+    main {
+        java {
+            srcDir("build/generated/sources/bufgen")
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":conformance:client")) {
+        exclude(group = "com.google.protobuf", module = "protobuf-javalite")
+    }
+    implementation(project(":extensions:google-java"))
+    implementation(project(":okhttp"))
+    implementation(libs.kotlin.coroutines.core)
+    implementation(libs.protobuf.kotlin)
+    implementation(libs.protobuf.java)
+    implementation(libs.okio.core)
+    implementation(libs.okhttp.tls)
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaBidiStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaBidiStreamClient.kt
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.BidiStreamClient
+import com.connectrpc.conformance.v1.BidiStreamRequest
+import com.connectrpc.conformance.v1.BidiStreamResponse
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+
+class JavaBidiStreamClient(
+    private val client: ConformanceServiceClient,
+) : BidiStreamClient<BidiStreamRequest, BidiStreamResponse>(
+    BidiStreamRequest.getDefaultInstance(),
+    BidiStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(headers: Headers): BidiStream<BidiStreamRequest, BidiStreamResponse> {
+        return BidiStream.new(client.bidiStream(headers))
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaClientStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaClientStreamClient.kt
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.ClientStreamClient
+import com.connectrpc.conformance.v1.ClientStreamRequest
+import com.connectrpc.conformance.v1.ClientStreamResponse
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+
+class JavaClientStreamClient(
+    private val client: ConformanceServiceClient,
+) : ClientStreamClient<ClientStreamRequest, ClientStreamResponse>(
+    ClientStreamRequest.getDefaultInstance(),
+    ClientStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(headers: Headers): ClientStream<ClientStreamRequest, ClientStreamResponse> {
+        return ClientStream.new(client.clientStream(headers))
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaInvoker.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaInvoker.kt
@@ -1,0 +1,62 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.SerializationStrategy
+import com.connectrpc.conformance.client.adapt.BidiStreamClient
+import com.connectrpc.conformance.client.adapt.ClientStreamClient
+import com.connectrpc.conformance.client.adapt.Invoker
+import com.connectrpc.conformance.client.adapt.ServerStreamClient
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.extensions.GoogleJavaJSONStrategy
+import com.connectrpc.extensions.GoogleJavaProtobufStrategy
+import com.connectrpc.impl.ProtocolClient
+import com.connectrpc.lite.connectrpc.conformance.v1.Codec
+
+class JavaInvoker(
+    protocolClient: ProtocolClient,
+) : Invoker {
+    private val client = ConformanceServiceClient(protocolClient)
+    override fun unaryClient(): UnaryClient<*, *> {
+        return JavaUnaryClient(client)
+    }
+
+    override fun unimplementedClient(): UnaryClient<*, *> {
+        return JavaUnimplementedClient(client)
+    }
+
+    override fun clientStreamClient(): ClientStreamClient<*, *> {
+        return JavaClientStreamClient(client)
+    }
+
+    override fun serverStreamClient(): ServerStreamClient<*, *> {
+        return JavaServerStreamClient(client)
+    }
+
+    override fun bidiStreamClient(): BidiStreamClient<*, *> {
+        return JavaBidiStreamClient(client)
+    }
+
+    companion object {
+        fun serializationStrategy(codec: Codec): SerializationStrategy {
+            return when (codec) {
+                Codec.CODEC_PROTO -> GoogleJavaProtobufStrategy()
+                Codec.CODEC_JSON -> GoogleJavaJSONStrategy()
+                else -> throw RuntimeException("unsupported codec $codec")
+            }
+        }
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
@@ -1,0 +1,35 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.ResponseStream
+import com.connectrpc.conformance.client.adapt.ServerStreamClient
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.conformance.v1.ServerStreamRequest
+import com.connectrpc.conformance.v1.ServerStreamResponse
+
+class JavaServerStreamClient(
+    private val client: ConformanceServiceClient,
+) : ServerStreamClient<ServerStreamRequest, ServerStreamResponse>(
+    ServerStreamRequest.getDefaultInstance(),
+    ServerStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(req: ServerStreamRequest, headers: Headers): ResponseStream<ServerStreamResponse> {
+        val stream = client.serverStream(headers)
+        stream.sendAndClose(req)
+        return ResponseStream.new(stream)
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnaryClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnaryClient.kt
@@ -1,0 +1,47 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.connectrpc.UnaryBlockingCall
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.conformance.v1.UnaryRequest
+import com.connectrpc.conformance.v1.UnaryResponse
+import com.connectrpc.http.Cancelable
+
+class JavaUnaryClient(
+    private val client: ConformanceServiceClient,
+) : UnaryClient<UnaryRequest, UnaryResponse>(
+    UnaryRequest.getDefaultInstance(),
+    UnaryResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(req: UnaryRequest, headers: Headers): ResponseMessage<UnaryResponse> {
+        return client.unary(req, headers)
+    }
+
+    override fun execute(
+        req: UnaryRequest,
+        headers: Headers,
+        onFinish: (ResponseMessage<UnaryResponse>) -> Unit,
+    ): Cancelable {
+        return client.unary(req, headers, onFinish)
+    }
+
+    override fun blocking(req: UnaryRequest, headers: Headers): UnaryBlockingCall<UnaryResponse> {
+        return client.unaryBlocking(req, headers)
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnimplementedClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnimplementedClient.kt
@@ -1,0 +1,47 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.connectrpc.UnaryBlockingCall
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.conformance.v1.UnimplementedRequest
+import com.connectrpc.conformance.v1.UnimplementedResponse
+import com.connectrpc.http.Cancelable
+
+class JavaUnimplementedClient(
+    private val client: ConformanceServiceClient,
+) : UnaryClient<UnimplementedRequest, UnimplementedResponse>(
+    UnimplementedRequest.getDefaultInstance(),
+    UnimplementedResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(req: UnimplementedRequest, headers: Headers): ResponseMessage<UnimplementedResponse> {
+        return client.unimplemented(req, headers)
+    }
+
+    override fun execute(
+        req: UnimplementedRequest,
+        headers: Headers,
+        onFinish: (ResponseMessage<UnimplementedResponse>) -> Unit,
+    ): Cancelable {
+        return client.unimplemented(req, headers, onFinish)
+    }
+
+    override fun blocking(req: UnimplementedRequest, headers: Headers): UnaryBlockingCall<UnimplementedResponse> {
+        return client.unimplementedBlocking(req, headers)
+    }
+}

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
@@ -1,0 +1,33 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.java
+
+import com.connectrpc.conformance.client.Client
+import com.connectrpc.conformance.client.ConformanceClientLoop
+
+fun main(args: Array<String>) {
+    try {
+        val invokeStyle = ConformanceClientLoop.parseArgs(args)
+        val client = Client(
+            invokerFactory = ::JavaInvoker,
+            serializationFactory = JavaInvoker::serializationStrategy,
+            invokeStyle = invokeStyle,
+        )
+        ConformanceClientLoop.run(System.`in`, System.out, client)
+    } catch (e: Exception) {
+        e.printStackTrace(System.err)
+        Runtime.getRuntime().exit(1)
+    }
+}

--- a/conformance/client/google-javalite/build.gradle.kts
+++ b/conformance/client/google-javalite/build.gradle.kts
@@ -1,0 +1,36 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
+    }
+}
+
+plugins {
+    kotlin("jvm")
+    id("com.github.johnrengelman.shadow").version("7.1.2")
+}
+
+tasks {
+    shadowJar {
+        archiveBaseName.set("shadow")
+        manifest {
+            attributes(mapOf("Main-Class" to "com.connectrpc.conformance.client.javalite.MainKt"))
+        }
+    }
+    build {
+        dependsOn(shadowJar)
+    }
+}
+
+dependencies {
+    implementation(project(":conformance:client"))
+    implementation(project(":extensions:google-javalite"))
+    implementation(project(":okhttp"))
+    implementation(libs.kotlin.coroutines.core)
+    implementation(libs.protobuf.kotlin)
+    implementation(libs.okio.core)
+    implementation(libs.okhttp.tls)
+}

--- a/conformance/client/google-javalite/build.gradle.kts
+++ b/conformance/client/google-javalite/build.gradle.kts
@@ -4,13 +4,13 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
+        classpath(libs.shadowjar)
     }
 }
 
 plugins {
     kotlin("jvm")
-    id("com.github.johnrengelman.shadow").version("7.1.2")
+    alias(libs.plugins.shadowjar)
 }
 
 tasks {
@@ -30,7 +30,7 @@ dependencies {
     implementation(project(":extensions:google-javalite"))
     implementation(project(":okhttp"))
     implementation(libs.kotlin.coroutines.core)
-    implementation(libs.protobuf.kotlin)
+    implementation(libs.protobuf.kotlinlite)
     implementation(libs.okio.core)
     implementation(libs.okhttp.tls)
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteBidiStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteBidiStreamClient.kt
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.BidiStreamClient
+import com.connectrpc.lite.connectrpc.conformance.v1.BidiStreamRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.BidiStreamResponse
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+
+class JavaLiteBidiStreamClient(
+    private val client: ConformanceServiceClient,
+) : BidiStreamClient<BidiStreamRequest, BidiStreamResponse>(
+    BidiStreamRequest.getDefaultInstance(),
+    BidiStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(headers: Headers): BidiStream<BidiStreamRequest, BidiStreamResponse> {
+        return BidiStream.new(client.bidiStream(headers))
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteClientStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteClientStreamClient.kt
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.ClientStreamClient
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientStreamRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientStreamResponse
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+
+class JavaLiteClientStreamClient(
+    private val client: ConformanceServiceClient,
+) : ClientStreamClient<ClientStreamRequest, ClientStreamResponse>(
+    ClientStreamRequest.getDefaultInstance(),
+    ClientStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(headers: Headers): ClientStream<ClientStreamRequest, ClientStreamResponse> {
+        return ClientStream.new(client.clientStream(headers))
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteInvoker.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteInvoker.kt
@@ -1,0 +1,61 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.SerializationStrategy
+import com.connectrpc.conformance.client.adapt.BidiStreamClient
+import com.connectrpc.conformance.client.adapt.ClientStreamClient
+import com.connectrpc.conformance.client.adapt.Invoker
+import com.connectrpc.conformance.client.adapt.ServerStreamClient
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.extensions.GoogleJavaLiteProtobufStrategy
+import com.connectrpc.impl.ProtocolClient
+import com.connectrpc.lite.connectrpc.conformance.v1.Codec
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+
+class JavaLiteInvoker(
+    protocolClient: ProtocolClient,
+) : Invoker {
+    private val client = ConformanceServiceClient(protocolClient)
+    override fun unaryClient(): UnaryClient<*, *> {
+        return JavaLiteUnaryClient(client)
+    }
+
+    override fun unimplementedClient(): UnaryClient<*, *> {
+        return JavaLiteUnimplementedClient(client)
+    }
+
+    override fun clientStreamClient(): ClientStreamClient<*, *> {
+        return JavaLiteClientStreamClient(client)
+    }
+
+    override fun serverStreamClient(): ServerStreamClient<*, *> {
+        return JavaLiteServerStreamClient(client)
+    }
+
+    override fun bidiStreamClient(): BidiStreamClient<*, *> {
+        return JavaLiteBidiStreamClient(client)
+    }
+
+    companion object {
+        fun serializationStrategy(codec: Codec): SerializationStrategy {
+            return when (codec) {
+                Codec.CODEC_PROTO -> GoogleJavaLiteProtobufStrategy()
+                Codec.CODEC_JSON -> throw RuntimeException("Java Lite does not support JSON")
+                else -> throw RuntimeException("unsupported codec $codec")
+            }
+        }
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteServerStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteServerStreamClient.kt
@@ -1,0 +1,35 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.Headers
+import com.connectrpc.conformance.client.adapt.ResponseStream
+import com.connectrpc.conformance.client.adapt.ServerStreamClient
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.lite.connectrpc.conformance.v1.ServerStreamRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.ServerStreamResponse
+
+class JavaLiteServerStreamClient(
+    private val client: ConformanceServiceClient,
+) : ServerStreamClient<ServerStreamRequest, ServerStreamResponse>(
+    ServerStreamRequest.getDefaultInstance(),
+    ServerStreamResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(req: ServerStreamRequest, headers: Headers): ResponseStream<ServerStreamResponse> {
+        val stream = client.serverStream(headers)
+        stream.sendAndClose(req)
+        return ResponseStream.new(stream)
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnaryClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnaryClient.kt
@@ -1,0 +1,50 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.connectrpc.UnaryBlockingCall
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.http.Cancelable
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.lite.connectrpc.conformance.v1.UnaryRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.UnaryResponse
+
+class JavaLiteUnaryClient(
+    private val client: ConformanceServiceClient,
+) : UnaryClient<UnaryRequest, UnaryResponse>(
+    UnaryRequest.getDefaultInstance(),
+    UnaryResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(
+        req: UnaryRequest,
+        headers: Headers,
+    ): ResponseMessage<UnaryResponse> {
+        return client.unary(req, headers)
+    }
+
+    override fun execute(
+        req: UnaryRequest,
+        headers: Headers,
+        onFinish: (ResponseMessage<UnaryResponse>) -> Unit,
+    ): Cancelable {
+        return client.unary(req, headers, onFinish)
+    }
+
+    override fun blocking(req: UnaryRequest, headers: Headers): UnaryBlockingCall<UnaryResponse> {
+        return client.unaryBlocking(req, headers)
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnimplementedClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnimplementedClient.kt
@@ -1,0 +1,47 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.connectrpc.UnaryBlockingCall
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.http.Cancelable
+import com.connectrpc.lite.connectrpc.conformance.v1.ConformanceServiceClient
+import com.connectrpc.lite.connectrpc.conformance.v1.UnimplementedRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.UnimplementedResponse
+
+class JavaLiteUnimplementedClient(
+    private val client: ConformanceServiceClient,
+) : UnaryClient<UnimplementedRequest, UnimplementedResponse>(
+    UnimplementedRequest.getDefaultInstance(),
+    UnimplementedResponse.getDefaultInstance(),
+) {
+    override suspend fun execute(req: UnimplementedRequest, headers: Headers): ResponseMessage<UnimplementedResponse> {
+        return client.unimplemented(req, headers)
+    }
+
+    override fun execute(
+        req: UnimplementedRequest,
+        headers: Headers,
+        onFinish: (ResponseMessage<UnimplementedResponse>) -> Unit,
+    ): Cancelable {
+        return client.unimplemented(req, headers, onFinish)
+    }
+
+    override fun blocking(req: UnimplementedRequest, headers: Headers): UnaryBlockingCall<UnimplementedResponse> {
+        return client.unimplementedBlocking(req, headers)
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
@@ -1,0 +1,33 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.javalite
+
+import com.connectrpc.conformance.client.Client
+import com.connectrpc.conformance.client.ConformanceClientLoop
+
+fun main(args: Array<String>) {
+    try {
+        val invokeStyle = ConformanceClientLoop.parseArgs(args)
+        val client = Client(
+            invokerFactory = ::JavaLiteInvoker,
+            serializationFactory = JavaLiteInvoker::serializationStrategy,
+            invokeStyle = invokeStyle,
+        )
+        ConformanceClientLoop.run(System.`in`, System.out, client)
+    } catch (e: Exception) {
+        e.printStackTrace(System.err)
+        Runtime.getRuntime().exit(1)
+    }
+}

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
@@ -18,16 +18,12 @@ import com.connectrpc.conformance.client.Client
 import com.connectrpc.conformance.client.ConformanceClientLoop
 
 fun main(args: Array<String>) {
-    try {
-        val invokeStyle = ConformanceClientLoop.parseArgs(args)
-        val client = Client(
-            invokerFactory = ::JavaLiteInvoker,
-            serializationFactory = JavaLiteInvoker::serializationStrategy,
-            invokeStyle = invokeStyle,
-        )
-        ConformanceClientLoop.run(System.`in`, System.out, client)
-    } catch (e: Exception) {
-        e.printStackTrace(System.err)
-        Runtime.getRuntime().exit(1)
-    }
+    val invokeStyle = ConformanceClientLoop.parseArgs(args)
+    val client = Client(
+        invokerFactory = ::JavaLiteInvoker,
+        serializationFactory = JavaLiteInvoker::serializationStrategy,
+        invokeStyle = invokeStyle,
+    )
+    ConformanceClientLoop.run(System.`in`, System.out, client)
+    // TODO: catch any exception for better error output/logging?
 }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -1,0 +1,242 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+import com.connectrpc.ProtocolClientConfig
+import com.connectrpc.RequestCompression
+import com.connectrpc.ResponseMessage
+import com.connectrpc.SerializationStrategy
+import com.connectrpc.compression.GzipCompressionPool
+import com.connectrpc.conformance.client.adapt.BidiStreamClient
+import com.connectrpc.conformance.client.adapt.ClientStreamClient
+import com.connectrpc.conformance.client.adapt.Invoker
+import com.connectrpc.conformance.client.adapt.ServerStreamClient
+import com.connectrpc.conformance.client.adapt.UnaryClient
+import com.connectrpc.impl.ProtocolClient
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientCompatRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientResponseResult
+import com.connectrpc.lite.connectrpc.conformance.v1.Codec
+import com.connectrpc.lite.connectrpc.conformance.v1.Compression
+import com.connectrpc.lite.connectrpc.conformance.v1.HTTPVersion
+import com.connectrpc.lite.connectrpc.conformance.v1.Protocol
+import com.connectrpc.lite.connectrpc.conformance.v1.StreamType
+import com.connectrpc.okhttp.ConnectOkHttpClient
+import com.connectrpc.protocols.GETConfiguration
+import com.connectrpc.protocols.NetworkProtocol
+import com.google.protobuf.MessageLite
+import okhttp3.OkHttpClient
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Duration
+import java.util.Base64
+import kotlin.reflect.cast
+import kotlin.reflect.safeCast
+
+class Client(
+    private val invokerFactory: (ProtocolClient) -> Invoker,
+    private val serializationFactory: (Codec) -> SerializationStrategy,
+    private val invokeStyle: UnaryClient.InvokeStyle,
+) {
+    suspend fun handle(req: ClientCompatRequest): ClientResponseResult {
+        val invoker = invokerFactory(getProtocolClient(req))
+        val service = req.service.orEmpty()
+        if (service != "connectrpc.conformance.v1.ConformanceService") {
+            throw RuntimeException("service $service is not known")
+        }
+
+        return when (val method = req.method.orEmpty()) {
+            "Unary" -> handleUnary(invoker.unaryClient(), req)
+            // TODO: IdempotentUnary
+            "Unimplemented" -> handleUnary(invoker.unimplementedClient(), req)
+            "ClientStream" -> handleClient(invoker.clientStreamClient(), req)
+            "ServerStream" -> handleServer(invoker.serverStreamClient(), req)
+            "BidiStream" -> if (req.streamType == StreamType.STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM) {
+                handleFullDuplexBidi(invoker.bidiStreamClient(), req)
+            } else {
+                handleHalfDuplexBidi(invoker.bidiStreamClient(), req)
+            }
+            else -> throw RuntimeException("method $method is not known")
+        }
+    }
+
+    private suspend fun <Req : MessageLite, Resp : MessageLite> handleUnary(
+        client: UnaryClient<Req, Resp>,
+        req: ClientCompatRequest,
+    ): ClientResponseResult {
+        TODO("implement me")
+    }
+
+    private suspend fun <Req : MessageLite, Resp : MessageLite> handleClient(
+        client: ClientStreamClient<Req, Resp>,
+        req: ClientCompatRequest,
+    ): ClientResponseResult {
+        TODO("implement me")
+    }
+
+    private suspend fun <Req : MessageLite, Resp : MessageLite> handleServer(
+        client: ServerStreamClient<Req, Resp>,
+        req: ClientCompatRequest,
+    ): ClientResponseResult {
+        TODO("implement me")
+    }
+
+    private suspend fun <Req : MessageLite, Resp : MessageLite> handleHalfDuplexBidi(
+        client: BidiStreamClient<Req, Resp>,
+        req: ClientCompatRequest,
+    ): ClientResponseResult {
+        TODO("implement me")
+    }
+
+    private suspend fun <Req : MessageLite, Resp : MessageLite> handleFullDuplexBidi(
+        client: BidiStreamClient<Req, Resp>,
+        req: ClientCompatRequest,
+    ): ClientResponseResult {
+        TODO("implement me")
+    }
+
+    private fun getProtocolClient(req: ClientCompatRequest): ProtocolClient {
+        // TODO: cache/re-use clients instead of creating a new one for every request
+        val serializationStrategy = serializationFactory(req.codec)
+        val scheme = if (req.serverTlsCert.isEmpty) "http" else "https"
+        val host = "$scheme://${req.host}:${req.port}"
+        var clientBuilder = OkHttpClient.Builder()
+            .protocols(listOf(asOkHttpProtocol(req.httpVersion)))
+            .connectTimeout(Duration.ofMinutes(1))
+        if (!req.serverTlsCert.isEmpty) {
+            val certs = certs(req)
+            clientBuilder = clientBuilder.sslSocketFactory(certs.sslSocketFactory(), certs.trustManager)
+        }
+        if (req.hasTimeoutMs()) {
+            clientBuilder = clientBuilder.callTimeout(Duration.ofMillis(req.timeoutMs.toLong()))
+        }
+
+        val getConfig = if (req.useGetHttpMethod) GETConfiguration.Enabled else GETConfiguration.Disabled
+        val requestCompression =
+            if (req.compression == Compression.COMPRESSION_GZIP) {
+                RequestCompression(10, GzipCompressionPool)
+            } else {
+                null
+            }
+        val compressionPools =
+            if (req.compression == Compression.COMPRESSION_GZIP) {
+                listOf(GzipCompressionPool)
+            } else {
+                emptyList()
+            }
+        return ProtocolClient(
+            httpClient = ConnectOkHttpClient(clientBuilder.build()),
+            ProtocolClientConfig(
+                host = host,
+                serializationStrategy = serializationStrategy,
+                networkProtocol = asNetworkProtocol(req.protocol),
+                getConfiguration = getConfig,
+                requestCompression = requestCompression,
+                compressionPools = compressionPools,
+            ),
+        )
+    }
+
+    private fun asNetworkProtocol(protocol: Protocol): NetworkProtocol {
+        return when (protocol) {
+            Protocol.PROTOCOL_CONNECT -> NetworkProtocol.CONNECT
+            Protocol.PROTOCOL_GRPC -> NetworkProtocol.GRPC
+            Protocol.PROTOCOL_GRPC_WEB -> NetworkProtocol.GRPC_WEB
+            else -> throw RuntimeException("unsupported protocol: $protocol")
+        }
+    }
+
+    private fun asOkHttpProtocol(httpVersion: HTTPVersion): okhttp3.Protocol {
+        return when (httpVersion) {
+            HTTPVersion.HTTP_VERSION_1 -> okhttp3.Protocol.HTTP_1_1
+            HTTPVersion.HTTP_VERSION_2 -> okhttp3.Protocol.HTTP_2
+            else -> throw RuntimeException("unsupported HTTP version: $httpVersion")
+        }
+    }
+
+    private fun certs(req: ClientCompatRequest): HandshakeCertificates {
+        val certificateAuthority = req.serverTlsCert.newInput().use { stream ->
+            CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
+        }
+        val result = HandshakeCertificates.Builder()
+            .addTrustedCertificate(certificateAuthority)
+
+        if (!req.hasClientTlsCreds()) {
+            return result.build()
+        }
+
+        val certificate = req.clientTlsCreds.cert.newInput().use { stream ->
+            CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
+        }
+        val publicKey = certificate.publicKey as RSAPublicKey
+        val privateKeyBytes = req.clientTlsCreds.key.newInput().bufferedReader().use { stream ->
+            val lines = stream.readLines().toMutableList()
+            // Remove BEGIN RSA PRIVATE KEY / END RSA PRIVATE KEY lines
+            lines.removeFirst()
+            lines.removeLast()
+            Base64.getDecoder().decode(lines.joinToString(separator = ""))
+        }
+        val privateKey = KeyFactory.getInstance("RSA")
+            .generatePrivate(PKCS8EncodedKeySpec(privateKeyBytes)) as RSAPrivateKey
+        if (publicKey.modulus != privateKey.modulus) {
+            throw Exception("key does not match cert") // or other error handling
+        }
+        return result
+            .heldCertificate(HeldCertificate(KeyPair(publicKey, privateKey), certificate))
+            .build()
+    }
+
+    private fun <From : MessageLite, To : MessageLite> convert(
+        from: From,
+        template: To,
+    ): To {
+        val clazz = template::class
+        return clazz.safeCast(from)
+            ?: clazz.cast(
+                template
+                    .newBuilderForType()
+                    .mergeFrom(from.toByteString())
+                    .build(),
+            )
+    }
+
+    private fun <From : MessageLite, To : MessageLite> convert(
+        from: ResponseMessage<From>,
+        template: To,
+    ): ResponseMessage<To> {
+        return when (from) {
+            is ResponseMessage.Success -> {
+                ResponseMessage.Success(
+                    message = convert(from.message, template),
+                    code = from.code,
+                    headers = from.headers,
+                    trailers = from.trailers,
+                )
+            }
+            is ResponseMessage.Failure -> {
+                // Value does not actually contain a reference
+                // to response type, so we can just cast it.
+                @Suppress("UNCHECKED_CAST")
+                from as ResponseMessage<To>
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ConformanceClientLoop.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ConformanceClientLoop.kt
@@ -1,0 +1,110 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+import com.connectrpc.conformance.client.adapt.UnaryClient.InvokeStyle
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientCompatRequest
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientCompatResponse
+import com.connectrpc.lite.connectrpc.conformance.v1.ClientErrorResult
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.runBlocking
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+
+class ConformanceClientLoop {
+    companion object {
+        fun run(input: InputStream, output: OutputStream, client: Client) = runBlocking {
+            // TODO: issue RPCs in parallel
+            while (true) {
+                var result: ClientCompatResponse
+                val req = readRequest(input) ?: return@runBlocking // end of stream
+                try {
+                    val resp = client.handle(req)
+                    result = ClientCompatResponse.newBuilder().setResponse(resp).build()
+                } catch (e: Exception) {
+                    val msg = if (e.message.orEmpty() == "") {
+                        e::class.qualifiedName
+                    } else {
+                        "${e::class.qualifiedName}: ${e.message}"
+                    }
+                    result = ClientCompatResponse.newBuilder()
+                        .setError(ClientErrorResult.newBuilder().setMessage(msg))
+                        .build()
+                }
+                writeResponse(output, result)
+            }
+        }
+
+        private fun readRequest(input: InputStream): ClientCompatRequest? {
+            val len = input.readInt() ?: return null
+            val data = input.readN(len)
+                ?: throw EOFException("unexpected EOF: read 0 of $len expected message bytes")
+            return ClientCompatRequest.parseFrom(ByteString.copyFrom(data))
+        }
+
+        private fun writeResponse(output: OutputStream, resp: ClientCompatResponse) {
+            val len = resp.serializedSize
+            val prefix = ByteArray(4)
+            prefix[0] = len.ushr(24).toByte()
+            prefix[1] = len.ushr(16).toByte()
+            prefix[2] = len.ushr(8).toByte()
+            prefix[3] = len.toByte()
+            output.write(prefix)
+            resp.writeTo(output)
+        }
+
+        private fun InputStream.readN(len: Int): ByteArray? {
+            val bytes = ByteArray(len)
+            var offs = 0
+            var remain = len
+            while (remain > 0) {
+                val n = this.read(bytes, offs, remain)
+                if (n == 0) {
+                    if (offs == 0) {
+                        return null
+                    }
+                    throw EOFException("unexpected EOF: read $offs of $len expected bytes")
+                }
+                offs += n
+                remain -= n
+            }
+            return bytes
+        }
+
+        private fun InputStream.readInt(): Int? {
+            val bytes = this.readN(4) ?: return null
+            return bytes[0].toInt().and(0xff).shl(24) or
+                bytes[1].toInt().and(0xff).shl(16) or
+                bytes[2].toInt().and(0xff).shl(8) or
+                bytes[3].toInt().and(0xff)
+        }
+
+        fun parseArgs(args: Array<String>): InvokeStyle {
+            if (args.isEmpty()) {
+                return InvokeStyle.SUSPEND
+            }
+            if (args.size > 1) {
+                throw IllegalArgumentException("expecting exactly one args (invoke style), but got ${args.size}")
+            }
+            return when (args[0].lowercase()) {
+                "suspend" -> InvokeStyle.SUSPEND
+                "blocking" -> InvokeStyle.BLOCKING
+                "callback" -> InvokeStyle.CALLBACK
+                else -> throw IllegalArgumentException("expecting one args to be 'suspend', 'blocking', or 'callback', but got '${args[0]}'")
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
@@ -1,0 +1,65 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.BidirectionalStreamInterface
+import com.connectrpc.Headers
+import com.google.protobuf.MessageLite
+
+/**
+ * The client of a bidi-stream RPC operation. A bidi-stream
+ * operation allows the client to upload zero or more request
+ * messages and to download zero or more response messages.
+ * Furthermore, bidi-stream operations can be "full duplex",
+ * which means that sending requests can be interleaved with
+ * receiving responses (whereas other stream types always
+ * require sending the request(s) first, and then receiving
+ * the response(s)).
+ *
+ * @param Req The request message type
+ * @param Resp The response message type
+ */
+abstract class BidiStreamClient<Req : MessageLite, Resp : MessageLite>(
+    val reqTemplate: Req,
+    val respTemplate: Resp,
+) {
+    abstract suspend fun execute(headers: Headers): BidiStream<Req, Resp>
+
+    /**
+     * A BidiStream combines a request stream and a response stream.
+     *
+     * @param Req The request message type
+     * @param Resp The response message type
+     */
+    interface BidiStream<Req : MessageLite, Resp : MessageLite> {
+        fun requests(): RequestStream<Req>
+        fun responses(): ResponseStream<Resp>
+        companion object {
+            fun <Req : MessageLite, Resp : MessageLite> new(underlying: BidirectionalStreamInterface<Req, Resp>): BidiStream<Req, Resp> {
+                val reqStream = RequestStream.new(underlying)
+                val respStream = ResponseStream.new(underlying)
+                return object : BidiStream<Req, Resp> {
+                    override fun requests(): RequestStream<Req> {
+                        return reqStream
+                    }
+
+                    override fun responses(): ResponseStream<Resp> {
+                        return respStream
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
@@ -1,0 +1,86 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.ClientOnlyStreamInterface
+import com.connectrpc.Code
+import com.connectrpc.ConnectException
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.google.protobuf.MessageLite
+
+/**
+ * The client of a client-stream RPC operation. A client-stream
+ * operation allows the client to upload zero or more request
+ * messages and then receive either a single response or an
+ * error when done.
+ *
+ * @param Req The request message type
+ * @param Resp The response message type
+ */
+
+abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
+    val reqTemplate: Req,
+    val respTemplate: Resp,
+) {
+    abstract suspend fun execute(headers: Headers): ClientStream<Req, Resp>
+
+    /**
+     * A ClientStream is just like a RequestStream, except that closing
+     * the stream waits for the operation result.
+     *
+     * @param Req The request message type
+     * @param Resp The response message type
+     */
+    interface ClientStream<Req : MessageLite, Resp : MessageLite> {
+        suspend fun send(req: Req)
+        suspend fun closeAndReceive(): ResponseMessage<Resp>
+
+        companion object {
+            fun <Req : MessageLite, Resp : MessageLite> new(underlying: ClientOnlyStreamInterface<Req, Resp>): ClientStream<Req, Resp> {
+                return object : ClientStream<Req, Resp> {
+                    override suspend fun send(req: Req) {
+                        underlying.send(req)
+                    }
+
+                    override suspend fun closeAndReceive(): ResponseMessage<Resp> {
+                        try {
+                            val resp = underlying.receiveAndClose()
+                            return ResponseMessage.Success(
+                                message = resp,
+                                code = Code.OK,
+                                headers = underlying.responseHeaders().await(),
+                                trailers = underlying.responseTrailers().await(),
+                            )
+                        } catch (e: Exception) {
+                            val connectException: ConnectException
+                            if (e is ConnectException) {
+                                connectException = e
+                            } else {
+                                connectException = ConnectException(code = Code.UNKNOWN, exception = e)
+                            }
+                            return ResponseMessage.Failure(
+                                cause = connectException,
+                                code = connectException.code,
+                                headers = underlying.responseHeaders().await(),
+                                trailers = underlying.responseTrailers().await(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Invoker.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Invoker.kt
@@ -1,0 +1,23 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+interface Invoker {
+    fun unaryClient(): UnaryClient<*, *>
+    fun unimplementedClient(): UnaryClient<*, *>
+    fun clientStreamClient(): ClientStreamClient<*, *>
+    fun serverStreamClient(): ServerStreamClient<*, *>
+    fun bidiStreamClient(): BidiStreamClient<*, *>
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
@@ -1,0 +1,42 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.BidirectionalStreamInterface
+import com.google.protobuf.MessageLite
+
+/**
+ * RequestStream is a stream that allows a client to upload
+ * zero or more request messages. When the client is done
+ * sending messages, it must close the stream.
+ */
+interface RequestStream<Req : MessageLite> {
+    suspend fun send(req: Req)
+    fun close()
+
+    companion object {
+        fun <Req : MessageLite, Resp : MessageLite> new(underlying: BidirectionalStreamInterface<Req, Resp>): RequestStream<Req> {
+            return object : RequestStream<Req> {
+                override suspend fun send(req: Req) {
+                    underlying.send(req)
+                }
+
+                override fun close() {
+                    underlying.sendClose()
+                }
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
@@ -1,0 +1,82 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.BidirectionalStreamInterface
+import com.connectrpc.Headers
+import com.connectrpc.ServerOnlyStreamInterface
+import com.google.protobuf.MessageLite
+import kotlinx.coroutines.channels.ReceiveChannel
+
+/**
+ * ResponseStream is a stream that allows a client to download
+ * zero or more request messages. Typically, the client should
+ * keep receiving messages until the end of the stream is reached.
+ * If the client closes the response stream before consuming all
+ * messages, the associated streaming RPC operation is cancelled.
+ *
+ * @param Resp The response message type
+ */
+interface ResponseStream<Resp : MessageLite> {
+    fun messages(): ReceiveChannel<Resp>
+
+    suspend fun headers(): Headers
+
+    suspend fun trailers(): Headers
+
+    fun close()
+
+    companion object {
+        fun <Req : MessageLite, Resp : MessageLite> new(underlying: BidirectionalStreamInterface<Req, Resp>): ResponseStream<Resp> {
+            return object : ResponseStream<Resp> {
+                override fun messages(): ReceiveChannel<Resp> {
+                    return underlying.responseChannel()
+                }
+
+                override suspend fun headers(): Headers {
+                    return underlying.responseHeaders().await()
+                }
+
+                override suspend fun trailers(): Headers {
+                    return underlying.responseTrailers().await()
+                }
+
+                override fun close() {
+                    underlying.receiveClose()
+                }
+            }
+        }
+
+        fun <Req : MessageLite, Resp : MessageLite> new(underlying: ServerOnlyStreamInterface<Req, Resp>): ResponseStream<Resp> {
+            return object : ResponseStream<Resp> {
+                override fun messages(): ReceiveChannel<Resp> {
+                    return underlying.responseChannel()
+                }
+
+                override suspend fun headers(): Headers {
+                    return underlying.responseHeaders().await()
+                }
+
+                override suspend fun trailers(): Headers {
+                    return underlying.responseTrailers().await()
+                }
+
+                override fun close() {
+                    underlying.receiveClose()
+                }
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
@@ -1,0 +1,33 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.Headers
+import com.google.protobuf.MessageLite
+
+/**
+ * The client of a server-stream RPC operation. A server-stream
+ * operation allows the client to send a single request and then
+ * download zero or more response messages.
+ *
+ * @param Req The request message type
+ * @param Resp The response message type
+ */
+abstract class ServerStreamClient<Req : MessageLite, Resp : MessageLite>(
+    val reqTemplate: Req,
+    val respTemplate: Resp,
+) {
+    abstract suspend fun execute(req: Req, headers: Headers): ResponseStream<Resp>
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/UnaryClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/UnaryClient.kt
@@ -1,0 +1,83 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+import com.connectrpc.Headers
+import com.connectrpc.ResponseMessage
+import com.connectrpc.UnaryBlockingCall
+import com.connectrpc.http.Cancelable
+import com.google.protobuf.MessageLite
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * The client of a unary RPC operation. This provides multiple ways
+ * to invoke the RPC: suspend-based async, callback-based async, or
+ * blocking.
+ *
+ * @param Req The request message type
+ * @param Resp The response message type
+ */
+abstract class UnaryClient<Req : MessageLite, Resp : MessageLite>(
+    val reqTemplate: Req,
+    val respTemplate: Resp,
+) {
+    abstract suspend fun execute(req: Req, headers: Headers): ResponseMessage<Resp>
+
+    abstract fun execute(req: Req, headers: Headers, onFinish: (ResponseMessage<Resp>) -> Unit): Cancelable
+
+    abstract fun blocking(req: Req, headers: Headers): UnaryBlockingCall<Resp>
+
+    suspend fun execute(
+        style: InvokeStyle,
+        req: Req,
+        headers: Headers,
+        onFinish: (ResponseMessage<Resp>) -> Unit,
+    ): Cancelable {
+        when (style) {
+            InvokeStyle.CALLBACK -> {
+                return execute(req, headers, onFinish)
+            }
+            InvokeStyle.SUSPEND -> {
+                return coroutineScope {
+                    val job = launch {
+                        onFinish(execute(req, headers))
+                    }
+                    return@coroutineScope {
+                        job.cancel()
+                    }
+                }
+            }
+            InvokeStyle.BLOCKING -> {
+                val call = blocking(req, headers)
+                coroutineScope {
+                    launch(Dispatchers.IO) {
+                        onFinish(call.execute())
+                    }
+                }
+                return {
+                    call.cancel()
+                }
+            }
+        }
+    }
+
+    enum class InvokeStyle {
+        CALLBACK,
+        SUSPEND,
+        BLOCKING,
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ moshi = "1.15.0"
 okhttp = "4.12.0"
 okio = "3.7.0"
 protobuf = "3.25.1"
+shadowjar = "7.1.2"
 slf4j = "2.0.9"
 spotless = "6.23.3"
 
@@ -52,6 +53,7 @@ protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", versio
 protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
 protobuf-kotlinlite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
+shadowjar = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "shadowjar" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 testcontainers = { module = "org.testcontainers:testcontainers", version = "1.19.3" }
@@ -59,4 +61,5 @@ testcontainers = { module = "org.testcontainers:testcontainers", version = "1.19
 [plugins]
 git = { id = "com.palantir.git-version", version = "3.0.0" }
 ksp = { id = "com.google.devtools.ksp", version = "1.9.21-1.0.16" }
+shadowjar = { id = "com.github.johnrengelman.shadow", version.ref = "shadowjar" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,8 @@
 rootProject.name = "connect-kotlin"
 
+include(":conformance:client")
+include(":conformance:client:google-java")
+include(":conformance:client:google-javalite")
 include(":conformance:common")
 include(":conformance:google-java")
 include(":conformance:google-javalite")


### PR DESCRIPTION
This PR is purely additive. It does not make any changes to the existing container/crosstest-based conformance test targets. It's just starting to add code to eventually replace all of that.

So the old conformance tests are in these modules:
- `conformance/common`
- `conformance/google-java`
- `conformance/google-javalite`

The new ones are in these:
- `conformance/client`
- `conformance/client/google-java`
- `conformance/client/google-javalite`

This doesn't include any actual logic yet. This was a rather substantial PR already, so I figured it would be good to get this approach reviewed before fleshing out the conformance client handler logic (which are all stubbed out in `Client.kt` with TODOs).

To avoid the redundant implementations of the current conformance tests, I'm doing the following:
1. Generate all conformance protos, using _lite_ runtime, into the `conformance/client` module. So the shared logic deals with the lite generated message types, since that's the lowest common denominator. (The full runtime should be able to correctly support lite generate code.)
2. This means that the `conformance/client/google-javalite` module doesn't need any add'l generated code.
3. The `conformance/client/google-java` module, on the other hand, does. So the shared code will convert from generated lite messages to normal/non-lite messages. This uses a `buf.gen.lite.yaml` which has a different package prefix, so both sets of generated messages can co-exist. The dependencies of the non-lite module _exclude_ the javalite protobuf runtime, swapping in the full runtime instead.

This also provides a glimpse of what I'm thinking about for an overhaul of the stream interfaces. In particular, see `BidiStreamClient.BidiStream`, `ServerStreamClient.ServerStream`, and `ClientStreamClient.ClientStream`. Currently, these contain adapters from the existing actual stream interfaces to these newer ones. But I'd like to overhaul the main stream interfaces to look more-or-less like these in the future, so let me know what you think.
