### PR TITLE
Fixes to get unary conformance test cases passing

### DIFF
--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
@@ -64,6 +64,8 @@ internal class GoogleJavaJSONAdapter<E : Message>(
         if (deterministic) {
             printer = printer.sortingMapKeys()
         }
+        // TODO: It would likely be more efficient to use printer.appendTo
+        //       with an Appendable implementation that wraps a Buffer.
         val jsonString = printer.print(message)
         return Buffer().write(jsonString.encodeUtf8())
     }

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONAdapter.kt
@@ -16,54 +16,55 @@ package com.connectrpc.extensions
 
 import com.connectrpc.CODEC_NAME_JSON
 import com.connectrpc.Codec
-import com.google.protobuf.GeneratedMessageV3
 import com.google.protobuf.Internal
+import com.google.protobuf.Message
+import com.google.protobuf.TypeRegistry
 import com.google.protobuf.util.JsonFormat
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString.Companion.encodeUtf8
 import kotlin.reflect.KClass
+import kotlin.reflect.cast
 
 /**
  * Adapter for Connect to use Google's protobuf-java runtime for
  * deserializing and serializing data types.
  */
-internal class GoogleJavaJSONAdapter<E : GeneratedMessageV3>(
-    clazz: KClass<E>,
+internal class GoogleJavaJSONAdapter<E : Message>(
+    private val clazz: KClass<E>,
+    private val registry: TypeRegistry,
 ) : Codec<E> {
-    /**
-     * Casting assumes the user is using Google's GeneratedMessageV3 type.
-     */
-    @Suppress("UNCHECKED_CAST")
     private val instance by lazy {
-        Internal.getDefaultInstance(clazz.java as Class<GeneratedMessageV3>)
+        Internal.getDefaultInstance(clazz.java)
     }
 
     override fun encodingName(): String {
         return CODEC_NAME_JSON
     }
 
-    /**
-     * Casting assumes the user is using Google's GeneratedMessageV3 type.
-     * The builder returns a GeneratedMessageV3 but it is assumed to be used
-     * with the assumption that the generic E is the underlying type.
-     */
-    @Suppress("UNCHECKED_CAST")
     override fun deserialize(source: BufferedSource): E {
-        val builder = instance.toBuilder()
-        JsonFormat.parser().ignoringUnknownFields().merge(source.readUtf8(), builder)
-        return builder.build() as E
+        val builder = instance.newBuilderForType()
+        JsonFormat.parser()
+            .ignoringUnknownFields()
+            .usingTypeRegistry(registry)
+            .merge(source.readUtf8(), builder)
+        return clazz.cast(builder.build())
     }
 
     override fun serialize(message: E): Buffer {
-        val jsonString = JsonFormat.printer().print(message)
-        return Buffer().write(jsonString.encodeUtf8())
+        return serialize(message, false)
     }
 
     override fun deterministicSerialize(message: E): Buffer {
-        val jsonString = JsonFormat.printer()
-            .sortingMapKeys()
-            .print(message)
+        return serialize(message, true)
+    }
+
+    private fun serialize(message: E, deterministic: Boolean): Buffer {
+        var printer = JsonFormat.printer()
+        if (deterministic) {
+            printer = printer.sortingMapKeys()
+        }
+        val jsonString = printer.print(message)
         return Buffer().write(jsonString.encodeUtf8())
     }
 }

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONStrategy.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaJSONStrategy.kt
@@ -35,7 +35,7 @@ class GoogleJavaJSONStrategy(
 
     override fun <E : Any> codec(clazz: KClass<E>): Codec<E> {
         if (!clazz.isSubclassOf(Message::class)) {
-            throw RuntimeException("class ${clazz.qualifiedName} does not extend MessageLite")
+            throw RuntimeException("class ${clazz.qualifiedName} does not extend Message")
         }
         @Suppress("UNCHECKED_CAST") // we just checked above, so it's safe
         val messageClass = clazz as KClass<out Message>

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
@@ -54,6 +54,10 @@ internal class GoogleJavaProtoAdapter<E : MessageLite>(
     }
 
     private fun serialize(message: E, deterministic: Boolean): Buffer {
+        // TODO: It would likely be more efficient to wrap a Buffer with
+        //       an OutputStream implementation so we don't have to
+        //       first create a separate byte array that gets copied to
+        //       buffer.
         val result = ByteArray(message.serializedSize)
         val output = CodedOutputStream.newInstance(result)
         if (deterministic) {

--- a/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
+++ b/extensions/google-java/src/main/kotlin/com/connectrpc/extensions/GoogleJavaProtoAdapter.kt
@@ -17,56 +17,50 @@ package com.connectrpc.extensions
 import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
 import com.google.protobuf.CodedOutputStream
-import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.ExtensionRegistryLite
 import com.google.protobuf.Internal
+import com.google.protobuf.MessageLite
 import okio.Buffer
 import okio.BufferedSource
-import java.io.IOException
 import kotlin.reflect.KClass
+import kotlin.reflect.cast
 
 /**
  * Adapter to use Google's protobuf-java runtime for
  * deserializing and serializing data types.
  */
-internal class GoogleJavaProtoAdapter<E : GeneratedMessageV3>(
-    clazz: KClass<E>,
+internal class GoogleJavaProtoAdapter<E : MessageLite>(
+    private val clazz: KClass<E>,
+    private val registry: ExtensionRegistryLite,
 ) : Codec<E> {
-    /**
-     * Casting assumes the user is using Google's GeneratedMessageV3 type.
-     */
-    @Suppress("UNCHECKED_CAST")
     private val instance by lazy {
-        Internal.getDefaultInstance(clazz.java as Class<GeneratedMessageV3>)
+        Internal.getDefaultInstance(clazz.java)
     }
 
     override fun encodingName(): String {
         return CODEC_NAME_PROTO
     }
 
-    /**
-     * Casting assumes the user is using Google's GeneratedMessageV3 type.
-     * The builder returns a GeneratedMessageV3 but it is assumed to be used
-     * with the assumption that the generic E is the underlying type.
-     */
-    @Suppress("UNCHECKED_CAST")
     override fun deserialize(source: BufferedSource): E {
-        return instance.parserForType.parseFrom(source.inputStream()) as E
+        return clazz.cast(instance.parserForType.parseFrom(source.inputStream(), registry))
     }
 
     override fun serialize(message: E): Buffer {
-        return Buffer().write(message.toByteArray())
+        return serialize(message, false)
     }
 
     override fun deterministicSerialize(message: E): Buffer {
-        return try {
-            val result = Buffer()
-            val output = CodedOutputStream.newInstance(result.outputStream())
+        return serialize(message, true)
+    }
+
+    private fun serialize(message: E, deterministic: Boolean): Buffer {
+        val result = ByteArray(message.serializedSize)
+        val output = CodedOutputStream.newInstance(result)
+        if (deterministic) {
             output.useDeterministicSerialization()
-            message.writeTo(output)
-            output.checkNoSpaceLeft()
-            result
-        } catch (e: IOException) {
-            throw RuntimeException("deterministic serialization failed", e)
         }
+        message.writeTo(output)
+        output.checkNoSpaceLeft()
+        return Buffer().write(result)
     }
 }

--- a/extensions/google-java/src/test/kotlin/com/connectrpc/extensions/JavaErrorParserTest.kt
+++ b/extensions/google-java/src/test/kotlin/com/connectrpc/extensions/JavaErrorParserTest.kt
@@ -34,7 +34,7 @@ class JavaErrorParserTest {
             .build()
         val serializedError = AnyError(
             "type.googleapis.com/google.rpc.Status",
-            proto.toByteArray().toByteString().base64().encodeUtf8(),
+            proto.toByteArray().toByteString(),
         )
         val unpacked = parser.unpack(serializedError, Status::class)
         assertThat(unpacked!!.code).isEqualTo(123)
@@ -59,13 +59,13 @@ class JavaErrorParserTest {
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_1")
-                    .setValue(ByteString.copyFrom("value_1".encodeUtf8().base64().encodeToByteArray()))
+                    .setValue(ByteString.copyFrom("value_1".encodeToByteArray()))
                     .build(),
             )
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_2")
-                    .setValue(ByteString.copyFrom("value_2".encodeUtf8().base64().encodeToByteArray()))
+                    .setValue(ByteString.copyFrom("value_2".encodeToByteArray()))
                     .build(),
             )
             .build()

--- a/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleJavaLiteProtobufStrategy.kt
+++ b/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleJavaLiteProtobufStrategy.kt
@@ -18,25 +18,31 @@ import com.connectrpc.CODEC_NAME_PROTO
 import com.connectrpc.Codec
 import com.connectrpc.ErrorDetailParser
 import com.connectrpc.SerializationStrategy
-import com.google.protobuf.GeneratedMessageLite
+import com.google.protobuf.ExtensionRegistryLite
+import com.google.protobuf.MessageLite
 import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
 
 /**
  * The Google Java-lite Protobuf serialization strategy.
  */
-class GoogleJavaLiteProtobufStrategy : SerializationStrategy {
+class GoogleJavaLiteProtobufStrategy(
+    private val registry: ExtensionRegistryLite = ExtensionRegistryLite.getEmptyRegistry(),
+) : SerializationStrategy {
     override fun serializationName(): String {
         return CODEC_NAME_PROTO
     }
 
-    /**
-     * This unchecked cast assumes the underlying class type is
-     * a Google GeneratedMessageLite.
-     */
-    @Suppress("UNCHECKED_CAST")
     override fun <E : Any> codec(clazz: KClass<E>): Codec<E> {
-        val messageClass = clazz as KClass<GeneratedMessageLite<out GeneratedMessageLite<*, *>, *>>
-        return GoogleLiteProtoAdapter(messageClass) as Codec<E>
+        if (!clazz.isSubclassOf(MessageLite::class)) {
+            throw RuntimeException("class ${clazz.qualifiedName} does not extend MessageLite")
+        }
+        @Suppress("UNCHECKED_CAST") // we just checked above, so it's safe
+        val messageClass = clazz as KClass<out MessageLite>
+
+        @Suppress("UNCHECKED_CAST") // messageClass is actually KClass<E>, so it's safe
+        val adapter = GoogleLiteProtoAdapter(messageClass, registry) as Codec<E>
+        return adapter
     }
 
     override fun errorDetailParser(): ErrorDetailParser {

--- a/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleLiteProtoAdapter.kt
+++ b/extensions/google-javalite/src/main/kotlin/com/connectrpc/extensions/GoogleLiteProtoAdapter.kt
@@ -54,6 +54,10 @@ internal class GoogleLiteProtoAdapter<E : MessageLite>(
     }
 
     private fun serialize(message: E, deterministic: Boolean): Buffer {
+        // TODO: It would likely be more efficient to wrap a Buffer with
+        //       an OutputStream implementation so we don't have to
+        //       first create a separate byte array that gets copied to
+        //       buffer.
         val result = ByteArray(message.serializedSize)
         val output = CodedOutputStream.newInstance(result)
         if (deterministic) {

--- a/extensions/google-javalite/src/test/kotlin/com/connectrpc/extensions/JavaLiteErrorParserTest.kt
+++ b/extensions/google-javalite/src/test/kotlin/com/connectrpc/extensions/JavaLiteErrorParserTest.kt
@@ -34,7 +34,7 @@ class JavaLiteErrorParserTest {
             .build()
         val serializedError = AnyError(
             "type.googleapis.com/com.connectrpc.google.rpc.Status",
-            proto.toByteArray().toByteString().base64().encodeUtf8(),
+            proto.toByteArray().toByteString(),
         )
         val unpacked = parser.unpack(serializedError, Status::class)
         assertThat(unpacked!!.code).isEqualTo(123)
@@ -59,13 +59,13 @@ class JavaLiteErrorParserTest {
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_1")
-                    .setValue(ByteString.copyFrom("value_1".encodeUtf8().base64().encodeToByteArray()))
+                    .setValue(ByteString.copyFrom("value_1".encodeToByteArray()))
                     .build(),
             )
             .addDetails(
                 com.google.protobuf.Any.newBuilder()
                     .setTypeUrl("any_message_2")
-                    .setValue(ByteString.copyFrom("value_2".encodeUtf8().base64().encodeToByteArray()))
+                    .setValue(ByteString.copyFrom("value_2".encodeToByteArray()))
                     .build(),
             )
             .build()

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
@@ -110,3 +110,11 @@ interface ProtocolClientInterface {
         methodSpec: MethodSpec<Input, Output>,
     ): ClientOnlyStreamInterface<Input, Output>
 }
+
+fun Headers.toLowercase(): Headers {
+    return asSequence().groupingBy {
+        it.key.lowercase()
+    }.aggregate { _: String, accumulator: List<String>?, element: Map.Entry<String, List<String>>, _: Boolean ->
+        accumulator?.plus(element.value) ?: element.value
+    }
+}

--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -18,6 +18,10 @@ package com.connectrpc
  * Typed unary response from an RPC.
  */
 sealed class ResponseMessage<Output>(
+    // TODO: remove code as its redundant with the code inside of
+    //       ConnectException in the error case and is always OK
+    //       in the success case.
+
     // The status code of the response.
     open val code: Code,
     // Response headers specified by the server.

--- a/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc.protocols
 
+import com.connectrpc.Headers
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -33,5 +34,5 @@ internal class ErrorDetailPayloadJSON(
 @JsonClass(generateAdapter = true)
 internal class EndStreamResponseJSON(
     @Json(name = "error") val error: ErrorPayloadJSON?,
-    @Json(name = "metadata") val metadata: Map<String, List<String>>?,
+    @Json(name = "metadata") val metadata: Headers?,
 )

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -244,7 +244,14 @@ internal class GRPCWebInterceptor(
             if (i > 0) {
                 val name = line.substring(0, i).trim()
                 val value = line.substring(i + 1).trim()
-                trailers[name.lowercase()] = listOf(value)
+                trailers.compute(name.lowercase()) { _: String, a: List<String>? ->
+                    if (a == null) {
+                        mutableListOf(value)
+                    } else {
+                        (a as MutableList).add(value)
+                        a
+                    }
+                }
             }
         }
         return trailers

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -284,7 +284,7 @@ class ConnectInterceptorTest {
             listOf(
                 ErrorDetailPayloadJSON(
                     "type",
-                    "value",
+                    "value".encodeUtf8().base64(),
                 ),
             ),
         )
@@ -567,7 +567,7 @@ class ConnectInterceptorTest {
             listOf(
                 ErrorDetailPayloadJSON(
                     "type",
-                    "value",
+                    "value".encodeUtf8().base64(),
                 ),
             ),
         )

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -142,6 +142,9 @@ internal fun codeFromIOException(e: IOException): Code {
     ) {
         Code.DEADLINE_EXCEEDED
     } else if (e.message?.lowercase() == "canceled") {
+        // TODO: Figure out what, if anything, actually throws an exception
+        //       with this message. It seems more likely that a JVM or
+        //       Kotlin coroutine exception would spell it with two Ls.
         Code.CANCELED
     } else {
         Code.UNKNOWN

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -35,8 +35,6 @@ import okio.BufferedSource
 import okio.Pipe
 import okio.buffer
 import java.io.IOException
-import java.io.InterruptedIOException
-import java.net.SocketTimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -88,17 +86,7 @@ private class ResponseCallback(
 ) : Callback {
     override fun onFailure(call: Call, e: IOException) {
         runBlocking {
-            if (e is InterruptedIOException) {
-                if (e.message == "timeout") {
-                    onResult(StreamResult.Complete(Code.DEADLINE_EXCEEDED, cause = e))
-                    return@runBlocking
-                }
-            }
-            if (e is SocketTimeoutException) {
-                onResult(StreamResult.Complete(Code.DEADLINE_EXCEEDED, cause = e))
-                return@runBlocking
-            }
-            onResult(StreamResult.Complete(Code.UNKNOWN, cause = e))
+            onResult(StreamResult.Complete(codeFromIOException(e), cause = e))
         }
     }
 


### PR DESCRIPTION
I had a branch where I got all of the unary test cases running and working with this repo. But it was very large, so I'm breaking it up.

First up are the changes to the actual runtime to get everything to work properly. There were numerous issues with things that were not really covered by the existing crosstest cases. In particular, error details and Connect GET flat-out didn't work. Also, there was no way to plumb extension or type registries through to the codec, so use of `google.protobuf.Any` with JSON format really couldn't work. There were some other little things I noticed and changed along the way. I'll drop a self-review and leave comments to explain each change and what it was trying to accomplish or why it was needed to fix things.