### PR TITLE
Implement unary operations in conformance client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Run conformance tests
-        run: make conformancerun
+        run: make runconformance
       - name: Upload test reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
@@ -23,20 +23,25 @@ import com.connectrpc.conformance.client.adapt.ClientCompatRequest.HttpVersion
 import com.connectrpc.conformance.client.adapt.ClientCompatRequest.TlsCreds
 import com.connectrpc.conformance.client.adapt.ClientCompatResponse
 import com.connectrpc.conformance.v1.BidiStreamResponse
+import com.connectrpc.conformance.v1.ClientCompatProto
 import com.connectrpc.conformance.v1.ClientCompatRequest.Cancel.CancelTimingCase
 import com.connectrpc.conformance.v1.ClientErrorResult
 import com.connectrpc.conformance.v1.ClientResponseResult
 import com.connectrpc.conformance.v1.ClientStreamResponse
 import com.connectrpc.conformance.v1.Codec
 import com.connectrpc.conformance.v1.Compression
+import com.connectrpc.conformance.v1.ConfigProto
 import com.connectrpc.conformance.v1.ConformancePayload
 import com.connectrpc.conformance.v1.Error
 import com.connectrpc.conformance.v1.HTTPVersion
 import com.connectrpc.conformance.v1.Header
 import com.connectrpc.conformance.v1.IdempotentUnaryResponse
 import com.connectrpc.conformance.v1.Protocol
+import com.connectrpc.conformance.v1.ServerCompatProto
 import com.connectrpc.conformance.v1.ServerStreamResponse
+import com.connectrpc.conformance.v1.ServiceProto
 import com.connectrpc.conformance.v1.StreamType
+import com.connectrpc.conformance.v1.SuiteProto
 import com.connectrpc.conformance.v1.UnaryResponse
 import com.connectrpc.conformance.v1.UnimplementedResponse
 import com.connectrpc.extensions.GoogleJavaJSONStrategy
@@ -45,6 +50,7 @@ import com.connectrpc.protocols.NetworkProtocol
 import com.google.protobuf.Any
 import com.google.protobuf.ByteString
 import com.google.protobuf.MessageLite
+import com.google.protobuf.TypeRegistry
 
 class JavaHelpers {
     companion object {
@@ -53,7 +59,7 @@ class JavaHelpers {
         fun serializationStrategy(codec: ClientCompatRequest.Codec): SerializationStrategy {
             return when (codec) {
                 ClientCompatRequest.Codec.PROTO -> GoogleJavaProtobufStrategy()
-                ClientCompatRequest.Codec.JSON -> GoogleJavaJSONStrategy()
+                ClientCompatRequest.Codec.JSON -> GoogleJavaJSONStrategy(getTypes())
                 else -> throw RuntimeException("unsupported codec $codec")
             }
         }
@@ -144,6 +150,16 @@ class JavaHelpers {
 
         private fun toTypeUrl(typeName: String): String {
             return if (typeName.contains('/')) typeName else TYPE_URL_PREFIX + typeName
+        }
+
+        private fun getTypes(): TypeRegistry {
+            return TypeRegistry.newBuilder()
+                .add(ClientCompatProto.getDescriptor().messageTypes)
+                .add(ConfigProto.getDescriptor().messageTypes)
+                .add(ServerCompatProto.getDescriptor().messageTypes)
+                .add(ServiceProto.getDescriptor().messageTypes)
+                .add(SuiteProto.getDescriptor().messageTypes)
+                .build()
         }
     }
 

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
@@ -15,18 +15,20 @@
 package com.connectrpc.conformance.client.java
 
 import com.connectrpc.conformance.client.Client
+import com.connectrpc.conformance.client.ClientArgs
 import com.connectrpc.conformance.client.ConformanceClientLoop
 
 fun main(args: Array<String>) {
-    val invokeStyle = ConformanceClientLoop.parseArgs(args)
+    val clientArgs = ClientArgs.parseArgs(args)
     val loop = ConformanceClientLoop(
         JavaHelpers::unmarshalRequest,
         JavaHelpers::marshalResponse,
+        clientArgs.verbosity,
     )
     val client = Client(
+        args = clientArgs,
         invokerFactory = ::JavaInvoker,
         serializationFactory = JavaHelpers::serializationStrategy,
-        invokeStyle = invokeStyle,
         payloadExtractor = JavaHelpers::extractPayload,
     )
     loop.run(System.`in`, System.out, client)

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
@@ -15,18 +15,20 @@
 package com.connectrpc.conformance.client.javalite
 
 import com.connectrpc.conformance.client.Client
+import com.connectrpc.conformance.client.ClientArgs
 import com.connectrpc.conformance.client.ConformanceClientLoop
 
 fun main(args: Array<String>) {
-    val invokeStyle = ConformanceClientLoop.parseArgs(args)
+    val clientArgs = ClientArgs.parseArgs(args)
     val loop = ConformanceClientLoop(
         JavaLiteHelpers::unmarshalRequest,
         JavaLiteHelpers::marshalResponse,
+        clientArgs.verbosity,
     )
     val client = Client(
+        args = clientArgs,
         invokerFactory = ::JavaLiteInvoker,
         serializationFactory = JavaLiteHelpers::serializationStrategy,
-        invokeStyle = invokeStyle,
         payloadExtractor = JavaLiteHelpers::extractPayload,
     )
     loop.run(System.`in`, System.out, client)

--- a/conformance/client/known-failing-cases.txt
+++ b/conformance/client/known-failing-cases.txt
@@ -1,0 +1,3 @@
+# Test runner is overly strict in asserting the contents
+# of the message query param, so these tests currently fail.
+Idempotency/**

--- a/conformance/client/lite-unary-config.yaml
+++ b/conformance/client/lite-unary-config.yaml
@@ -1,0 +1,24 @@
+# This configures the features that this client
+# supports and that will be verified by the
+# conformance test suite.
+features:
+  versions:
+    - HTTP_VERSION_1
+    - HTTP_VERSION_2
+  protocols:
+    - PROTOCOL_CONNECT
+    - PROTOCOL_GRPC
+    - PROTOCOL_GRPC_WEB
+  codecs:
+    - CODEC_PROTO
+    # Lite does not support JSON
+  compressions:
+    - COMPRESSION_IDENTITY
+    - COMPRESSION_GZIP
+  streamTypes:
+    # This config file only runs unary RPC test cases,
+    # so that we can run them all three ways: suspend,
+    # callback, and blocking.
+    - STREAM_TYPE_UNARY
+  supportsTlsClientCerts: true
+  supportsHalfDuplexBidiOverHttp1: true

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
@@ -1,0 +1,76 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+import com.connectrpc.conformance.client.adapt.UnaryClient.InvokeStyle
+
+data class ClientArgs(
+    val invokeStyle: InvokeStyle,
+    val verbosity: Int,
+) {
+    companion object {
+        fun parseArgs(args: Array<String>): ClientArgs {
+            var invokeStyle = InvokeStyle.SUSPEND
+            var verbosity = 0
+            var skip = false
+            for (i in args.indices) {
+                if (skip) {
+                    skip = false
+                    continue
+                }
+                when (val arg = args[i]) {
+                    "-s", "--style" -> {
+                        if (i == args.size - 1) {
+                            throw RuntimeException("$arg option requires a value")
+                        }
+                        skip = true // consuming next string now
+                        val v = args[i + 1]
+                        when (v.lowercase()) {
+                            "suspend" -> {
+                                invokeStyle = InvokeStyle.SUSPEND
+                            }
+                            "callback" -> {
+                                invokeStyle = InvokeStyle.CALLBACK
+                            }
+                            "blocking" -> {
+                                invokeStyle = InvokeStyle.BLOCKING
+                            }
+                            else -> {
+                                throw RuntimeException("value for $arg option should be 'suspend', 'callback', or 'blocking'; instead got '$v'")
+                            }
+                        }
+                    }
+                    "-v" -> {
+                        verbosity = 1
+                    }
+                    "-vv" -> {
+                        verbosity = 2
+                    }
+                    "-vvv" -> {
+                        verbosity = 3
+                    }
+                    else -> {
+                        if (arg.startsWith("-")) {
+                            throw RuntimeException("unknown option: $arg")
+                        } else {
+                            throw RuntimeException("this command does not accept positional arguments")
+                        }
+                    }
+                }
+            }
+            return ClientArgs(invokeStyle, verbosity)
+        }
+    }
+}

--- a/conformance/client/standard-unary-config.yaml
+++ b/conformance/client/standard-unary-config.yaml
@@ -1,0 +1,24 @@
+# This configures the features that this client
+# supports and that will be verified by the
+# conformance test suite.
+features:
+  versions:
+    - HTTP_VERSION_1
+    - HTTP_VERSION_2
+  protocols:
+    - PROTOCOL_CONNECT
+    - PROTOCOL_GRPC
+    - PROTOCOL_GRPC_WEB
+  codecs:
+    - CODEC_PROTO
+    - CODEC_JSON
+  compressions:
+    - COMPRESSION_IDENTITY
+    - COMPRESSION_GZIP
+  streamTypes:
+    # This config file only runs unary RPC test cases,
+    # so that we can run them all three ways: suspend,
+    # callback, and blocking.
+    - STREAM_TYPE_UNARY
+  supportsTlsClientCerts: true
+  supportsHalfDuplexBidiOverHttp1: true


### PR DESCRIPTION
This also adds support for other command-line args, to enable verbose tracing output (which was handy for troubleshooting stuff).

Other repos use the make target `runconformance`, but this repo was using `conformancerun`, so I changed it. That target still runs the old cross test stuff, but it also now runs these new unary conformance test cases. The config file is what indicates unary-only. The "known failing" file is because the assertions in the test runner for Connect GET requests are too strict -- AFAICT, this client now passes those tests. The only failing assertion is about the `message` query param that the server gets because it is expecting the encoding in a particular way, but that is not necessary (but requires a change in the test runner to relax the assertion).

The `Makefile` downloads the conformance test runner in the same fashion as it downloads `protoc`.