### PR TITLE
Some cleanup, mostly in the HTTP request representations

### DIFF
--- a/library/src/main/kotlin/com/connectrpc/Interceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/Interceptor.kt
@@ -16,6 +16,7 @@ package com.connectrpc
 
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
+import com.connectrpc.http.UnaryHTTPRequest
 import okio.Buffer
 
 /**
@@ -52,7 +53,7 @@ interface Interceptor {
 }
 
 class UnaryFunction(
-    val requestFunction: (HTTPRequest) -> HTTPRequest = { it },
+    val requestFunction: (UnaryHTTPRequest) -> UnaryHTTPRequest = { it },
     val responseFunction: (HTTPResponse) -> HTTPResponse = { it },
 )
 

--- a/library/src/main/kotlin/com/connectrpc/compression/CompressionPool.kt
+++ b/library/src/main/kotlin/com/connectrpc/compression/CompressionPool.kt
@@ -37,15 +37,15 @@ interface CompressionPool {
 
     /**
      * Compress an outbound request message.
-     * @param buffer: The uncompressed request message.
+     * @param input: The uncompressed request message.
      * @return The compressed request message.
      */
-    fun compress(buffer: Buffer): Buffer
+    fun compress(input: Buffer): Buffer
 
     /**
      * Decompress an inbound response message.
-     * @param buffer: The compressed response message.
+     * @param input: The compressed response message.
      * @return The uncompressed response message.
      */
-    fun decompress(buffer: Buffer): Buffer
+    fun decompress(input: Buffer): Buffer
 }

--- a/library/src/main/kotlin/com/connectrpc/compression/GzipCompressionPool.kt
+++ b/library/src/main/kotlin/com/connectrpc/compression/GzipCompressionPool.kt
@@ -28,20 +28,23 @@ object GzipCompressionPool : CompressionPool {
         return "gzip"
     }
 
-    override fun compress(buffer: Buffer): Buffer {
-        val gzippedSink = Buffer()
-        GzipSink(gzippedSink).use { source ->
-            source.write(buffer, buffer.size)
+    override fun compress(input: Buffer): Buffer {
+        val result = Buffer()
+        GzipSink(result).use { gzippedSink ->
+            gzippedSink.write(input, input.size)
         }
-        return gzippedSink
+        return result
     }
 
-    override fun decompress(buffer: Buffer): Buffer {
+    override fun decompress(input: Buffer): Buffer {
         val result = Buffer()
-        if (buffer.size == 0L) return result
+        // We're lenient and will allow an empty payload to be
+        // interpreted as a compressed empty payload (even though
+        // it's missing the gzip format preamble/metadata).
+        if (input.size == 0L) return result
 
-        GzipSource(buffer).use {
-            while (it.read(result, Int.MAX_VALUE.toLong()) != -1L) {
+        GzipSource(input).use { gzippedSource ->
+            while (gzippedSource.read(result, Int.MAX_VALUE.toLong()) != -1L) {
                 // continue reading.
             }
         }

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -33,7 +33,7 @@ interface HTTPClientInterface {
      *
      * @return A function to cancel the underlying network call.
      */
-    fun unary(request: HTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable
+    fun unary(request: UnaryHTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable
 
     /**
      * Initialize a new HTTP stream.

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
@@ -19,9 +19,11 @@ import com.connectrpc.MethodSpec
 import okio.Buffer
 import java.net.URL
 
-internal object HTTPMethod {
-    internal const val GET = "GET"
-    internal const val POST = "POST"
+enum class HTTPMethod(
+    val string: String,
+) {
+    GET("GET"),
+    POST("POST"),
 }
 
 /**
@@ -36,9 +38,6 @@ open class HTTPRequest internal constructor(
     val headers: Headers,
     // The method spec associated with the request.
     val methodSpec: MethodSpec<*, *>,
-    // HTTP method to use with the request.
-    // Almost always POST, but side effect free unary RPCs may be made with GET.
-    val httpMethod: String = HTTPMethod.POST,
 )
 
 /**
@@ -56,15 +55,12 @@ fun HTTPRequest.clone(
     headers: Headers = this.headers,
     // The method spec associated with the request.
     methodSpec: MethodSpec<*, *> = this.methodSpec,
-    // The HTTP method to use with the request.
-    httpMethod: String = this.httpMethod,
 ): HTTPRequest {
     return HTTPRequest(
         url,
         contentType,
         headers,
         methodSpec,
-        httpMethod,
     )
 }
 
@@ -85,8 +81,8 @@ class UnaryHTTPRequest(
     val message: Buffer,
     // HTTP method to use with the request.
     // Almost always POST, but side effect free unary RPCs may be made with GET.
-    httpMethod: String = HTTPMethod.POST,
-) : HTTPRequest(url, contentType, headers, methodSpec, httpMethod)
+    val httpMethod: HTTPMethod = HTTPMethod.POST,
+) : HTTPRequest(url, contentType, headers, methodSpec)
 
 fun UnaryHTTPRequest.clone(
     // The URL for the request.
@@ -100,7 +96,7 @@ fun UnaryHTTPRequest.clone(
     // Body data for the request.
     message: Buffer = this.message,
     // The HTTP method to use with the request.
-    httpMethod: String = this.httpMethod,
+    httpMethod: HTTPMethod = this.httpMethod,
 ): UnaryHTTPRequest {
     return UnaryHTTPRequest(
         url,

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -30,6 +30,7 @@ import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.http.Cancelable
 import com.connectrpc.http.HTTPClientInterface
 import com.connectrpc.http.HTTPRequest
+import com.connectrpc.http.UnaryHTTPRequest
 import com.connectrpc.http.transform
 import com.connectrpc.protocols.GETConfiguration
 import kotlinx.coroutines.CompletableDeferred
@@ -79,12 +80,12 @@ class ProtocolClient(
             } else {
                 requestCodec.serialize(request)
             }
-            val unaryRequest = HTTPRequest(
+            val unaryRequest = UnaryHTTPRequest(
                 url = urlFromMethodSpec(methodSpec),
                 contentType = "application/${requestCodec.encodingName()}",
                 headers = headers,
-                message = requestMessage.readByteArray(),
                 methodSpec = methodSpec,
+                message = requestMessage,
             )
             val unaryFunc = config.createInterceptorChain()
             val finalRequest = unaryFunc.requestFunction(unaryRequest)

--- a/library/src/main/kotlin/com/connectrpc/protocols/Envelope.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/Envelope.kt
@@ -30,26 +30,23 @@ class Envelope {
          * @param compressionMinBytes The minimum bytes the source needs to be in order to be compressed.
          */
         fun pack(source: Buffer, compressionPool: CompressionPool? = null, compressionMinBytes: Int? = null): Buffer {
+            val flags: Int
+            val payload: Buffer
             if (compressionMinBytes == null ||
                 source.size < compressionMinBytes ||
                 compressionPool == null
             ) {
-                return source.use {
-                    val result = Buffer()
-                    result.writeByte(0)
-                    result.writeInt(source.buffer.size.toInt())
-                    result.writeAll(source)
-                    result
-                }
+                flags = 0
+                payload = source
+            } else {
+                flags = 1
+                payload = compressionPool.compress(source)
             }
-            return source.use { buffer ->
-                val result = Buffer()
-                result.writeByte(1)
-                val compressedBuffer = compressionPool.compress(buffer)
-                result.writeInt(compressedBuffer.size.toInt())
-                result.writeAll(compressedBuffer)
-                result
-            }
+            val result = Buffer()
+            result.writeByte(flags)
+            result.writeInt(payload.buffer.size.toInt())
+            result.writeAll(payload)
+            return result
         }
 
         /**

--- a/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
@@ -21,6 +21,7 @@ import com.connectrpc.SerializationStrategy
 import com.connectrpc.StreamType
 import com.connectrpc.http.HTTPClientInterface
 import com.connectrpc.http.HTTPRequest
+import com.connectrpc.http.UnaryHTTPRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -50,7 +51,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) { _ -> }
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/com.connectrpc.SomeService/Service")
     }
@@ -67,7 +68,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) { _ -> }
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/com.connectrpc.SomeService/Service")
     }
@@ -84,7 +85,7 @@ class ProtocolClientTest {
                 emptyMap(),
                 createMethodSpec(StreamType.BIDI),
             )
-            val captor = argumentCaptor<HTTPRequest>()
+            val captor = argumentCaptor<UnaryHTTPRequest>()
             verify(httpClient).stream(captor.capture(), true, any())
             assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/com.connectrpc.SomeService/Service")
         }
@@ -119,7 +120,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) {}
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/com.connectrpc.SomeService/Service")
     }
@@ -135,7 +136,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) {}
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/com.connectrpc.SomeService/Service")
     }
@@ -151,7 +152,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) {}
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/api/com.connectrpc.SomeService/Service")
     }
@@ -167,7 +168,7 @@ class ProtocolClientTest {
             emptyMap(),
             createMethodSpec(StreamType.UNARY),
         ) {}
-        val captor = argumentCaptor<HTTPRequest>()
+        val captor = argumentCaptor<UnaryHTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
         assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/api/com.connectrpc.SomeService/Service")
     }

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -30,11 +30,10 @@ import com.connectrpc.http.HTTPMethod
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.TracingInfo
+import com.connectrpc.http.UnaryHTTPRequest
 import com.squareup.moshi.Moshi
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
-import okio.internal.commonAsUtf8ToByteArray
-import okio.internal.commonToUtf8String
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -71,10 +70,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -102,10 +102,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("User-Agent" to listOf("custom-user-agent")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -129,11 +130,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -142,7 +143,7 @@ class ConnectInterceptorTest {
                 ),
             ),
         )
-        assertThat(request.message!!.commonToUtf8String()).isEqualTo("message")
+        assertThat(request.message.readUtf8()).isEqualTo("message")
     }
 
     @Test
@@ -157,11 +158,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -170,7 +171,7 @@ class ConnectInterceptorTest {
                 ),
             ),
         )
-        val decompressed = GzipCompressionPool.decompress(Buffer().write(request.message!!))
+        val decompressed = GzipCompressionPool.decompress(request.message)
         assertThat(decompressed.readUtf8()).isEqualTo("message")
     }
 
@@ -186,11 +187,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = emptyMap(),
-                message = "".commonAsUtf8ToByteArray(),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -199,7 +200,7 @@ class ConnectInterceptorTest {
                 ),
             ),
         )
-        val decompressed = GzipCompressionPool.decompress(Buffer().write(request.message!!))
+        val decompressed = GzipCompressionPool.decompress(request.message)
         assertThat(decompressed.readUtf8()).isEqualTo("")
     }
 
@@ -679,11 +680,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
-                message = ByteArray(5_000),
+                message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -716,11 +717,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
-                message = ByteArray(5_000),
+                message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -745,11 +746,11 @@ class ConnectInterceptorTest {
         val connectInterceptor = ConnectInterceptor(config)
         val unaryFunction = connectInterceptor.unaryFunction()
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
-                message = ByteArray(5_000),
+                message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -779,11 +780,11 @@ class ConnectInterceptorTest {
         val unaryFunction = connectInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
-                message = ByteArray(5_000),
+                message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -28,10 +28,10 @@ import com.connectrpc.compression.GzipCompressionPool
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.TracingInfo
+import com.connectrpc.http.UnaryHTTPRequest
 import com.squareup.moshi.Moshi
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
-import okio.internal.commonAsUtf8ToByteArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -65,10 +65,11 @@ class GRPCInterceptorTest {
         val unaryFunction = grpcInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -93,10 +94,11 @@ class GRPCInterceptorTest {
         val unaryFunction = grpcInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = mapOf("key" to listOf("value"), "User-Agent" to listOf("my-custom-user-agent")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -120,11 +122,11 @@ class GRPCInterceptorTest {
         val unaryFunction = grpcInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -133,7 +135,7 @@ class GRPCInterceptorTest {
                 ),
             ),
         )
-        val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
+        val (_, message) = Envelope.unpackWithHeaderByte(request.message)
         assertThat(message.readUtf8()).isEqualTo("message")
     }
 
@@ -149,11 +151,11 @@ class GRPCInterceptorTest {
         val unaryFunction = grpcInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -162,7 +164,7 @@ class GRPCInterceptorTest {
                 ),
             ),
         )
-        val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
+        val (_, message) = Envelope.unpackWithHeaderByte(request.message)
         val decompressed = GzipCompressionPool.decompress(message)
         assertThat(decompressed.readUtf8()).isEqualTo("message")
     }

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -27,9 +27,9 @@ import com.connectrpc.compression.GzipCompressionPool
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.TracingInfo
+import com.connectrpc.http.UnaryHTTPRequest
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
-import okio.internal.commonAsUtf8ToByteArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -61,10 +61,11 @@ class GRPCWebInterceptorTest {
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
                 headers = mapOf("key" to listOf("value")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -90,10 +91,11 @@ class GRPCWebInterceptorTest {
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
                 headers = mapOf("X-User-Agent" to listOf("custom-user-agent")),
+                message = Buffer(),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -117,11 +119,11 @@ class GRPCWebInterceptorTest {
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -130,7 +132,7 @@ class GRPCWebInterceptorTest {
                 ),
             ),
         )
-        val (_, message) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!))
+        val (_, message) = Envelope.unpackWithHeaderByte(request.message)
         assertThat(message.readUtf8()).isEqualTo("message")
     }
 
@@ -146,11 +148,11 @@ class GRPCWebInterceptorTest {
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
         val request = unaryFunction.requestFunction(
-            HTTPRequest(
+            UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
                 headers = emptyMap(),
-                message = "message".commonAsUtf8ToByteArray(),
+                message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
                     path = "",
                     requestClass = Any::class,
@@ -159,7 +161,7 @@ class GRPCWebInterceptorTest {
                 ),
             ),
         )
-        val (_, decompressed) = Envelope.unpackWithHeaderByte(Buffer().write(request.message!!), GzipCompressionPool)
+        val (_, decompressed) = Envelope.unpackWithHeaderByte(request.message, GzipCompressionPool)
         assertThat(decompressed.readUtf8()).isEqualTo("message")
     }
 

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -101,7 +101,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
             }
         }
         val content = request.message
-        val method = request.httpMethod
+        val method = request.httpMethod.string
         val requestBody = if (HttpMethod.requiresRequestBody(method)) {
             object : RequestBody() {
                 override fun contentType() = request.contentType.toMediaType()
@@ -191,7 +191,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
         duplex: Boolean,
         onResult: suspend (StreamResult<Buffer>) -> Unit,
     ): Stream {
-        return streamClient.initializeStream(request.httpMethod, request, duplex, onResult)
+        return streamClient.initializeStream(request, duplex, onResult)
     }
 }
 

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -23,6 +23,7 @@ import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.Stream
 import com.connectrpc.http.TracingInfo
+import com.connectrpc.http.UnaryHTTPRequest
 import com.connectrpc.protocols.CONNECT_PROTOCOL_VERSION_KEY
 import com.connectrpc.protocols.CONNECT_PROTOCOL_VERSION_VALUE
 import com.connectrpc.protocols.GETConstants
@@ -34,10 +35,11 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody
 import okhttp3.Response
 import okhttp3.internal.http.HttpMethod
 import okio.Buffer
+import okio.BufferedSink
 import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
@@ -91,16 +93,31 @@ class ConnectOkHttpClient @JvmOverloads constructor(
         }
     }
 
-    override fun unary(request: HTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable {
+    override fun unary(request: UnaryHTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable {
         val builder = Request.Builder()
         for (entry in request.headers) {
             for (values in entry.value) {
                 builder.addHeader(entry.key, values)
             }
         }
-        val content = request.message ?: ByteArray(0)
+        val content = request.message
         val method = request.httpMethod
-        val requestBody = if (HttpMethod.requiresRequestBody(method)) content.toRequestBody(request.contentType.toMediaType()) else null
+        val requestBody = if (HttpMethod.requiresRequestBody(method)) {
+            object : RequestBody() {
+                override fun contentType() = request.contentType.toMediaType()
+                override fun contentLength() = content.size
+                override fun writeTo(sink: BufferedSink) {
+                    // We make a copy so that this body is not "one shot",
+                    // meaning that the okhttp library may automatically
+                    // retry the request under certain conditions. If we
+                    // didn't copy it, then reading it here would consume
+                    // it and then a retry would only see an empty body.
+                    content.copy().readAll(sink)
+                }
+            }
+        } else {
+            null
+        }
         val callRequest = builder
             .url(request.url)
             .method(method, requestBody)

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -17,6 +17,7 @@ package com.connectrpc.okhttp
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import com.connectrpc.StreamResult
+import com.connectrpc.http.HTTPMethod
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.Stream
 import kotlinx.coroutines.runBlocking
@@ -42,7 +43,6 @@ import java.util.concurrent.CountDownLatch
  * This is responsible for creating a bidirectional stream with OkHttp.
  */
 internal fun OkHttpClient.initializeStream(
-    method: String,
     request: HTTPRequest,
     duplex: Boolean,
     onResult: suspend (StreamResult<Buffer>) -> Unit,
@@ -50,7 +50,7 @@ internal fun OkHttpClient.initializeStream(
     val requestBody = PipeRequestBody(duplex, request.contentType.toMediaType())
     val builder = Request.Builder()
         .url(request.url)
-        .method(method, requestBody)
+        .method(HTTPMethod.POST.string, requestBody) // streams are always POSTs
     for (entry in request.headers) {
         for (values in entry.value) {
             builder.addHeader(entry.key, values)


### PR DESCRIPTION
This PR contains a few changes that try to improve parts of the code.

1. The first commit is the biggest chunk, which clarifies the representation of HTTP requests. Previously the `HTTPRequest` class _might_ have a request message. This message was really required for unary operations (and, if absent, would be treated as empty request) and ignored for stream operations. So now the type is split into two: a base `HTTPRequest` which has no request message, and a `UnaryHTTPRequest` which has a non-optional message type. Also, since everything in the framework works with `Buffer` for messages, this changes the type of the message from `ByteArray` to `Buffer`.
2. One of the changes in the second commit was just renaming some variables/parameters in the compression stuff to (IMO) make it a little easier to read. (I was in this part of the code because an early suspicion with one of the streaming errors in the conformance tests was in the gzip implementation, since it seemed to only happen for gzip'ed requests.)
3. Another small change in the second commit was me trying to make `Envelope.pack` a little more DRY. Though, looking at it again, it doesn't really reduce the total number of lines of code and is perhaps too Go-like and not very idiomatic for Kotlin... Let me know what you think. I can easily back it out.
4. The final change (also in the second commit) is really a bug fix. I didn't include it in #210 since it wasn't actually causing any issues in the conformance tests -- at least not yet (we're currently adding some test cases that would tickle it though). When a gRPC operation completes, this was treating missing trailers as a successful RPC, as if the trailers were present and indicated a status of "ok". But that is not correct -- missing trailers in the gRPC protocol means something is definitely wrong (even if it's a unary operation that includes the singular response message). So now the client will consider this case to be an RPC error.