### PR TITLE
Enhance verbose output of conformance client and enable stream conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,16 +69,12 @@ runconformancenew: generate $(CONNECT_CONFORMANCE) ## Run the new conformance te
 		--known-failing conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style blocking
-
-# TODO: Add streaming conformance tests. Currently, a small number of the test cases
-# are flaky, so leaving this commented out for now.
-# (Will continue investigating and address soon).
-#	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-stream-config.yaml \
-#		--known-failing conformance/client/known-failing-stream-cases.txt -- \
-#		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite
-#	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-stream-config.yaml \
-#		--known-failing conformance/client/known-failing-stream-cases.txt -- \
-#		conformance/client/google-java/build/install/google-java/bin/google-java
+	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-stream-config.yaml \
+		--known-failing conformance/client/known-failing-stream-cases.txt -- \
+		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite
+	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-stream-config.yaml \
+		--known-failing conformance/client/known-failing-stream-cases.txt -- \
+		conformance/client/google-java/build/install/google-java/bin/google-java
 
 .PHONY: runcrosstests
 runcrosstests: generate ## Run the old cross-test suite.

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
@@ -84,7 +84,9 @@ class JavaHelpers {
                     if (err != null) {
                         respBuilder.setError(toProtoError(err))
                     }
-                    builder.setResponse(respBuilder)
+                    val respMsg = respBuilder.build()
+                    result.response.raw = respMsg
+                    builder.setResponse(respMsg)
                 }
                 is ClientCompatResponse.Result.ErrorResult -> {
                     builder.setError(
@@ -166,6 +168,8 @@ class JavaHelpers {
     private class ClientCompatRequestImpl(
         private val msg: com.connectrpc.conformance.v1.ClientCompatRequest,
     ) : ClientCompatRequest {
+        override val raw: kotlin.Any
+            get() = msg
         override val testName: String
             get() = msg.testName
         override val service: String

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/Main.kt
@@ -23,7 +23,7 @@ fun main(args: Array<String>) {
     val loop = ConformanceClientLoop(
         JavaHelpers::unmarshalRequest,
         JavaHelpers::marshalResponse,
-        clientArgs.verbosity,
+        clientArgs.verbose,
     )
     val client = Client(
         args = clientArgs,

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteHelpers.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteHelpers.kt
@@ -76,7 +76,9 @@ class JavaLiteHelpers {
                     if (err != null) {
                         respBuilder.setError(toProtoError(err))
                     }
-                    builder.setResponse(respBuilder)
+                    val respMsg = respBuilder.build()
+                    result.response.raw = respMsg
+                    builder.setResponse(respMsg)
                 }
                 is ClientCompatResponse.Result.ErrorResult -> {
                     builder.setError(
@@ -148,6 +150,8 @@ class JavaLiteHelpers {
     private class ClientCompatRequestImpl(
         private val msg: com.connectrpc.conformance.v1.ClientCompatRequest,
     ) : ClientCompatRequest {
+        override val raw: kotlin.Any
+            get() = msg
         override val testName: String
             get() = msg.testName
         override val service: String

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/Main.kt
@@ -23,7 +23,7 @@ fun main(args: Array<String>) {
     val loop = ConformanceClientLoop(
         JavaLiteHelpers::unmarshalRequest,
         JavaLiteHelpers::marshalResponse,
-        clientArgs.verbosity,
+        clientArgs.verbose,
     )
     val client = Client(
         args = clientArgs,

--- a/conformance/client/known-failing-stream-cases.txt
+++ b/conformance/client/known-failing-stream-cases.txt
@@ -1,15 +1,6 @@
-# OkHttp seems to have a bug where timeout is not properly
-# enforced when request body is full-duplex.
+# We currently rely on OkHttp's "call timeout" to handle
+# RPC deadlines, but that is not enforced when the request
+# body is duplex. So timeouts don't currently work with
+# bidi streams.
 Timeouts/HTTPVersion:2/**/bidi half duplex timeout
 Timeouts/HTTPVersion:2/**/bidi full duplex timeout
-
-# Connect-kotlin does not have a way to limit the size of messages
-# received. It probably should. Despite this, many cases in this suite
-# still pass, so they are likely not exercising what we think they are.
-# TODO: add flag to config yaml for whether implementation supports
-#       a receive size limit
-Client Message Size/**/Compression:COMPRESSION_GZIP/TLS:false/**/client stream first request exceeds client limit
-Client Message Size/**/Compression:COMPRESSION_GZIP/TLS:false/**/client stream subsequent request exceeds client limit
-Client Message Size/**/Compression:COMPRESSION_GZIP/TLS:false/**/client stream all requests equal to client limit
-Client Message Size/**/Compression:COMPRESSION_GZIP/TLS:false/**/server stream request equal to client limit
-Client Message Size/**/Compression:COMPRESSION_GZIP/TLS:false/**/server stream request exceeds client limit

--- a/conformance/client/lite-stream-config.yaml
+++ b/conformance/client/lite-stream-config.yaml
@@ -23,3 +23,4 @@ features:
     - STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
   # TODO: get client certs working and uncomment this
   #supportsTlsClientCerts: true
+  supportsMessageReceiveLimit: false

--- a/conformance/client/lite-unary-config.yaml
+++ b/conformance/client/lite-unary-config.yaml
@@ -22,3 +22,4 @@ features:
     - STREAM_TYPE_UNARY
   # TODO: get client certs working and uncomment this
   #supportsTlsClientCerts: true
+  supportsMessageReceiveLimit: false

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
@@ -53,24 +53,16 @@ data class ClientArgs(
                         }
                     }
                     "-v" -> {
-                        // see if there's a value
-                        if (i < args.size - 1 && !args[i + 1].startsWith("-")) {
-                            skip = true // consuming next string now
-                            val v = args[i + 1]
-                            val intVal = v.toIntOrNull()
-                            if (intVal == null || intVal < 1 || intVal > 5) {
-                                throw RuntimeException("value for $arg option should be an integer between 1 and 5; instead got '$v'")
-                            }
-                            verbosity = intVal
-                        } else {
-                            verbosity = 1
+                        if (i == args.size - 1) {
+                            throw RuntimeException("$arg option requires a value")
                         }
-                    }
-                    "-vv" -> {
-                        verbosity = 2
-                    }
-                    "-vvv" -> {
-                        verbosity = 3
+                        skip = true // consuming next string now
+                        val v = args[i + 1]
+                        val intVal = v.toIntOrNull()
+                        if (intVal == null || intVal < 1 || intVal > 5) {
+                            throw RuntimeException("value for $arg option should be an integer between 1 and 5; instead got '$v'")
+                        }
+                        verbosity = intVal
                     }
                     else -> {
                         if (arg.startsWith("-")) {

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ClientArgs.kt
@@ -18,7 +18,7 @@ import com.connectrpc.conformance.client.adapt.UnaryClient.InvokeStyle
 
 data class ClientArgs(
     val invokeStyle: InvokeStyle,
-    val verbosity: Int,
+    val verbose: VerbosePrinter,
 ) {
     companion object {
         fun parseArgs(args: Array<String>): ClientArgs {
@@ -53,7 +53,18 @@ data class ClientArgs(
                         }
                     }
                     "-v" -> {
-                        verbosity = 1
+                        // see if there's a value
+                        if (i < args.size - 1 && !args[i + 1].startsWith("-")) {
+                            skip = true // consuming next string now
+                            val v = args[i + 1]
+                            val intVal = v.toIntOrNull()
+                            if (intVal == null || intVal < 1 || intVal > 5) {
+                                throw RuntimeException("value for $arg option should be an integer between 1 and 5; instead got '$v'")
+                            }
+                            verbosity = intVal
+                        } else {
+                            verbosity = 1
+                        }
                     }
                     "-vv" -> {
                         verbosity = 2
@@ -70,7 +81,7 @@ data class ClientArgs(
                     }
                 }
             }
-            return ClientArgs(invokeStyle, verbosity)
+            return ClientArgs(invokeStyle, VerbosePrinter(verbosity, "* client: "))
         }
     }
 }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ConformanceClientLoop.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/ConformanceClientLoop.kt
@@ -30,39 +30,43 @@ import java.io.OutputStream
 class ConformanceClientLoop(
     private val requestUnmarshaller: (ByteArray) -> ClientCompatRequest,
     private val responseMarshaller: (ClientCompatResponse) -> ByteArray,
-    private val verbosity: Int = 0,
+    private val verbose: VerbosePrinter,
 ) {
     fun run(input: InputStream, output: OutputStream, client: Client) = runBlocking {
         // TODO: issue RPCs in parallel
         while (true) {
             var result: ClientCompatResponse.Result
             val req = readRequest(input) ?: return@runBlocking // end of stream
-            if (verbosity > 0) {
-                System.err.println("* client: read request for test ${req.testName}")
+            verbose.verbosity(1) {
+                println("read request for test ${req.testName}")
+                verbose.verbosity(3) {
+                    println("RPC request:")
+                    indent().println("${req.raw}")
+                }
             }
             try {
                 val resp = client.handle(req)
                 result = ClientCompatResponse.Result.ResponseResult(resp)
-                if (verbosity > 0) {
-                    System.err.println("* client: RPC completed for test ${req.testName}")
+                verbose.verbosity(1) {
+                    println("RPC completed for test ${req.testName}")
                 }
-            } catch (e: Exception) {
-                if (verbosity > 0) {
-                    System.err.println("* client: RPC could not be issued for test ${req.testName}")
-                    e.printStackTrace()
+            } catch (ex: Exception) {
+                verbose.verbosity(1) {
+                    println("RPC could not be issued for test ${req.testName}")
+                    indent().println(ex.stackTraceToString())
                 }
-                val msg = if (e.message.orEmpty() == "") {
-                    e::class.qualifiedName.orEmpty()
+                val msg = if (ex.message.orEmpty() == "") {
+                    ex::class.qualifiedName.orEmpty()
                 } else {
-                    "${e::class.qualifiedName}: ${e.message}"
+                    "${ex::class.qualifiedName}: ${ex.message}"
                 }
                 result = ClientCompatResponse.Result.ErrorResult(msg)
             }
             if (result is ClientCompatResponse.Result.ResponseResult && result.response.error != null) {
-                if (verbosity > 2) {
+                verbose.verbosity(2) {
                     val ex = result.response.error!!
-                    System.err.println("* client: RPC failed with code ${ex.code}")
-                    ex.printStackTrace()
+                    println("RPC failed with code ${ex.code} for test ${req.testName}:")
+                    indent().println(ex.stackTraceToString())
                 }
             }
             writeResponse(
@@ -72,6 +76,12 @@ class ConformanceClientLoop(
                     result = result,
                 ),
             )
+            if (result is ClientCompatResponse.Result.ResponseResult && result.response.raw != null) {
+                verbose.verbosity(3) {
+                    println("RPC result:")
+                    indent().println("${result.response.raw}")
+                }
+            }
         }
     }
 

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/OkHttpEventTracer.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/OkHttpEventTracer.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc.conformance.client
 
+import com.connectrpc.okhttp.originalCode
 import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.EventListener
@@ -69,7 +70,7 @@ internal class OkHttpEventTracer(
         printer.printlnWithStackTrace("reading response headers...")
     }
     override fun responseHeadersEnd(call: Call, response: Response) {
-        printer.printlnWithStackTrace("response headers read: status code = ${response.code}")
+        printer.printlnWithStackTrace("response headers read: status code = ${response.originalCode()}")
     }
     override fun responseBodyStart(call: Call) {
         printer.printlnWithStackTrace("reading response body...")

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/OkHttpEventTracer.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/OkHttpEventTracer.kt
@@ -1,0 +1,83 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.EventListener
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+internal class OkHttpEventTracer(
+    private val printer: VerbosePrinter.Printer,
+) : EventListener() {
+    override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
+        printer.printlnWithStackTrace("connecting to $inetSocketAddress...")
+    }
+    override fun connectEnd(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?,
+    ) {
+        printer.printlnWithStackTrace("connected to $inetSocketAddress")
+    }
+    override fun connectFailed(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?,
+        ioe: IOException,
+    ) {
+        printer.printlnWithStackTrace("connect to $inetSocketAddress failed")
+    }
+    override fun connectionAcquired(call: Call, connection: Connection) {
+        printer.printlnWithStackTrace("connection to ${connection.socket().remoteSocketAddress} acquired")
+    }
+    override fun requestHeadersStart(call: Call) {
+        printer.printlnWithStackTrace("writing request headers...")
+    }
+    override fun requestHeadersEnd(call: Call, request: Request) {
+        printer.printlnWithStackTrace("request headers written")
+    }
+    override fun requestBodyStart(call: Call) {
+        printer.printlnWithStackTrace("writing request body...")
+    }
+    override fun requestBodyEnd(call: Call, byteCount: Long) {
+        printer.printlnWithStackTrace("request body written: $byteCount bytes")
+    }
+    override fun requestFailed(call: Call, ioe: IOException) {
+        printer.printlnWithStackTrace("request failed: ${ioe.message}")
+    }
+    override fun responseHeadersStart(call: Call) {
+        printer.printlnWithStackTrace("reading response headers...")
+    }
+    override fun responseHeadersEnd(call: Call, response: Response) {
+        printer.printlnWithStackTrace("response headers read: status code = ${response.code}")
+    }
+    override fun responseBodyStart(call: Call) {
+        printer.printlnWithStackTrace("reading response body...")
+    }
+    override fun responseBodyEnd(call: Call, byteCount: Long) {
+        printer.printlnWithStackTrace("response body read: $byteCount bytes")
+    }
+    override fun responseFailed(call: Call, ioe: IOException) {
+        printer.printlnWithStackTrace("response failed: ${ioe.message}")
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/TracingHTTPClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/TracingHTTPClient.kt
@@ -1,0 +1,118 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+import com.connectrpc.StreamResult
+import com.connectrpc.http.Cancelable
+import com.connectrpc.http.HTTPClientInterface
+import com.connectrpc.http.HTTPRequest
+import com.connectrpc.http.HTTPResponse
+import com.connectrpc.http.Stream
+import com.connectrpc.http.UnaryHTTPRequest
+import okio.Buffer
+
+internal class TracingHTTPClient(
+    private val delegate: HTTPClientInterface,
+    private val printer: VerbosePrinter.Printer,
+) : HTTPClientInterface {
+    override fun unary(request: UnaryHTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable {
+        printer.printlnWithStackTrace("Sending unary request (${request.message.size} bytes): ${request.httpMethod} ${request.url}")
+        val cancel = delegate.unary(request) { response ->
+            val buffer = Buffer()
+            buffer.writeAll(response.message)
+            if (response.cause != null) {
+                printer.println("Failed to receive HTTP response (${buffer.size} bytes): ${response.cause!!.message.orEmpty()}")
+                printer.indent().println(response.cause!!.stackTraceToString())
+            } else {
+                printer.println("Received HTTP response (${buffer.size} bytes): ${response.tracingInfo?.httpStatus ?: "???"}")
+            }
+            onResult(
+                HTTPResponse(
+                    code = response.code,
+                    headers = response.headers,
+                    message = buffer,
+                    trailers = response.trailers,
+                    tracingInfo = response.tracingInfo,
+                    cause = response.cause,
+                ),
+            )
+        }
+        return {
+            printer.println("Canceling HTTP request...")
+            cancel()
+        }
+    }
+
+    override fun stream(
+        request: HTTPRequest,
+        duplex: Boolean,
+        onResult: suspend (StreamResult<Buffer>) -> Unit,
+    ): Stream {
+        printer.printlnWithStackTrace("Sending HTTP stream request: POST ${request.url}")
+        val stream = delegate.stream(request, duplex) { result ->
+            when (result) {
+                is StreamResult.Headers -> {
+                    printer.printlnWithStackTrace("Received HTTP response headers")
+                }
+                is StreamResult.Message -> {
+                    printer.printlnWithStackTrace("Received HTTP response data (${result.message.size} bytes)")
+                }
+                is StreamResult.Complete -> {
+                    if (result.cause != null) {
+                        printer.printlnWithStackTrace("Failed to complete HTTP response (code=${result.code}): ${result.cause!!.message.orEmpty()}")
+                    } else {
+                        printer.printlnWithStackTrace("Received HTTP response completion: code=${result.code}")
+                    }
+                }
+            }
+            onResult(result)
+        }
+        return TracingStream(stream, printer)
+    }
+
+    private class TracingStream(
+        private val delegate: Stream,
+        private val printer: VerbosePrinter.Printer,
+    ) : Stream {
+        override suspend fun send(buffer: Buffer): Result<Unit> {
+            val size = buffer.size
+            val res = delegate.send(buffer)
+            if (res.isFailure) {
+                printer.printlnWithStackTrace("Failed to send HTTP request data ($size bytes): ${res.exceptionOrNull()!!.message}")
+            } else {
+                printer.printlnWithStackTrace("Sent HTTP request data ($size bytes)")
+            }
+            return res
+        }
+
+        override fun sendClose() {
+            printer.printlnWithStackTrace("Half-closing stream")
+            delegate.sendClose()
+        }
+
+        override fun receiveClose() {
+            printer.printlnWithStackTrace("Closing stream")
+            delegate.receiveClose()
+        }
+
+        override fun isSendClosed(): Boolean {
+            return delegate.isSendClosed()
+        }
+
+        override fun isReceiveClosed(): Boolean {
+            return delegate.isReceiveClosed()
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/VerbosePrinter.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/VerbosePrinter.kt
@@ -1,0 +1,112 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client
+
+/**
+ * Helper for printing verbose output. This can be useful
+ * for troubleshooting and debugging.
+ */
+class VerbosePrinter(
+    private val verbosity: Int,
+    private val prefix: String,
+) {
+    companion object {
+        /**
+         * Verbosity required to log optional stack traces.
+         */
+        private const val STACK_TRACE_VERBOSITY = 5
+
+        /**
+         * Lock used to synchronize all output so that concurrent
+         * threads printing don't interleave optional stack traces
+         * (which makes them much harder to read)
+         */
+        private val lock = Object()
+    }
+
+    private val output = PrinterImpl(verbosity, prefix)
+
+    /**
+     * Runs the given block with the given verbosity. If the
+     * given verbosity is higher than the currently configured
+     * output, the block will not be executed.
+     */
+    fun verbosity(v: Int, block: Printer.() -> Unit) {
+        if (v > verbosity) return
+        block(output)
+    }
+
+    /**
+     * Returns a new printer with the given additional prefix
+     * added to each printed line.
+     */
+    fun withPrefix(prefix: String): VerbosePrinter {
+        return VerbosePrinter(verbosity, this.prefix + prefix)
+    }
+
+    /**
+     * Prints verbose messages.
+     */
+    interface Printer {
+        fun println(s: String)
+
+        /**
+         * Like `println` but will also record a stack trace
+         * of the caller if verbosity is sufficiently high.
+         */
+        fun printlnWithStackTrace(s: String)
+
+        /**
+         * Returns a printer whose output is prefixed with an
+         * extra indentation (tab stop).
+         */
+        fun indent(): Printer
+    }
+
+    private class PrinterImpl(
+        private val verbosity: Int,
+        private val prefix: String,
+    ) : Printer {
+        override fun println(s: String) {
+            synchronized(lock) {
+                s.splitToSequence("\n").forEach {
+                    System.err.println("${prefix}$it")
+                }
+            }
+        }
+        override fun printlnWithStackTrace(s: String) {
+            synchronized(lock) {
+                println(s)
+                if (verbosity < STACK_TRACE_VERBOSITY) {
+                    return
+                }
+                println(
+                    RuntimeException()
+                        .stackTraceToString()
+                        // Skip first two lines. First one is the exception
+                        // type and message. Second one is stack-frame for
+                        // this function.
+                        .substringAfter("\n")
+                        .substringAfter("\n")
+                        // Trim trailing newline.
+                        .trimEnd('\n'),
+                )
+            }
+        }
+        override fun indent(): Printer {
+            return PrinterImpl(verbosity, prefix + "\t")
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientCompatRequest.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientCompatRequest.kt
@@ -56,6 +56,8 @@ interface ClientCompatRequest {
     val requestMessages: List<AnyMessage>
     val cancel: Cancel?
 
+    val raw: Any // the underlying message or object
+
     interface TlsCreds {
         val cert: ByteString
         val key: ByteString

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientResponseResult.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientResponseResult.kt
@@ -31,4 +31,9 @@ class ClientResponseResult(
     val trailers: Headers = emptyMap(),
     val error: ConnectException? = null,
     val numUnsentRequests: Int = 0,
+
+    /**
+     * Set to underlying message or object during marshal.
+     */
+    var raw: Any? = null,
 )

--- a/conformance/client/standard-stream-config.yaml
+++ b/conformance/client/standard-stream-config.yaml
@@ -23,3 +23,4 @@ features:
     - STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
   # TODO: get client certs working and uncomment this
   #supportsTlsClientCerts: true
+  supportsMessageReceiveLimit: false

--- a/conformance/client/standard-unary-config.yaml
+++ b/conformance/client/standard-unary-config.yaml
@@ -22,3 +22,4 @@ features:
     - STREAM_TYPE_UNARY
   # TODO: get client certs working and uncomment this
   #supportsTlsClientCerts: true
+  supportsMessageReceiveLimit: false

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -216,7 +216,7 @@ internal fun codeFromException(callCanceled: Boolean, e: Exception): Code {
 
 internal const val REVISED_CODE_SUFFIX = " |originally 408|"
 
-internal fun Response.originalCode(): Int {
+fun Response.originalCode(): Int {
     // 499 code could have been translated from 408 on the wire
     // (via network interceptor, to avoid okhttp's auto-retry on
     // 408 status codes). If so, return the original 408.


### PR DESCRIPTION
This adds verbose output features to the conformance client. There are now 5 levels of verbosity -- `-v`, `-vv`, and `-vvv` can be used to turn on the first three; `-v 4` and `-v 5` can be used to turn on the heavier trace output.

I used this output, along with a newly added `--trace` flag to the conformance test runner, to troubleshoot the streaming failures. (This PR, #210, and #211 represent all of the changes made to get everything to work.)

The levels of verbosity are:
1. Prints the start and end of each test case. If an error occurs, prints the exception's stack trace.
2. Prints exception stack traces for all RPC errors encountered and any errors that occur when calling `send`. (These could be expected errors, for tests of error conditions, which is why they are not enabled at verbosity 1).
3. Prints the full messages read from stdin and results written to stdout (in protobuf text format). Also adds a tracing decorator to the `HTTPClientInterface` implementation, to print out each step in an RPC.
4. Adds an okhttp event logger, to trace each step in the underlying HTTP framework.
5. Turns on stack-trace logging for the above okhttp event logger and `HTTPClientInterface` tracing, so that each step shows its full stack trace (useful since some operations can happen from different threads).

This PR also applies some clean-up to the conformance configs and ... 🥁 ... enables all of the conformance tests! They now should all pass.