### PR TITLE
Provide way to auto-close streams

### DIFF
--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -36,14 +36,12 @@ import com.connectrpc.conformance.client.adapt.Invoker
 import com.connectrpc.conformance.client.adapt.ResponseStream
 import com.connectrpc.conformance.client.adapt.ServerStreamClient
 import com.connectrpc.conformance.client.adapt.UnaryClient
-import com.connectrpc.conformance.client.adapt.execute
 import com.connectrpc.http.HTTPClientInterface
 import com.connectrpc.impl.ProtocolClient
 import com.connectrpc.okhttp.ConnectOkHttpClient
 import com.connectrpc.protocols.GETConfiguration
 import com.google.protobuf.MessageLite
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
@@ -153,7 +151,7 @@ class Client(
     private suspend fun <Req : MessageLite, Resp : MessageLite> handleClient(
         client: ClientStreamClient<Req, Resp>,
         req: ClientCompatRequest,
-    ): ClientResponseResult = coroutineScope {
+    ): ClientResponseResult {
         if (req.streamType != StreamType.CLIENT_STREAM) {
             throw RuntimeException("specified method ${req.method} is client-stream but stream type indicates ${req.streamType}")
         }
@@ -163,7 +161,7 @@ class Client(
         ) {
             throw RuntimeException("client stream calls can only support `BeforeCloseSend` and 'AfterCloseSendMs' cancellation field, instead got ${req.cancel!!::class.simpleName}")
         }
-        client.execute(req.requestHeaders) { stream ->
+        return client.execute(req.requestHeaders) { stream ->
             var numUnsent = 0
             for (i in req.requestMessages.indices) {
                 if (req.requestDelayMs > 0) {

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
@@ -60,7 +60,7 @@ abstract class BidiStreamClient<Req : MessageLite, Resp : MessageLite>(
      * @param Req The request message type
      * @param Resp The response message type
      */
-    interface BidiStream<Req : MessageLite, Resp : MessageLite> : Closeable {
+    interface BidiStream<Req : MessageLite, Resp : MessageLite> : SuspendCloseable {
         val requests: RequestStream<Req>
         val responses: ResponseStream<Resp>
 

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
@@ -60,7 +60,7 @@ abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
      * @param Req The request message type
      * @param Resp The response message type
      */
-    interface ClientStream<Req : MessageLite, Resp : MessageLite> : Closeable {
+    interface ClientStream<Req : MessageLite, Resp : MessageLite> : SuspendCloseable {
         suspend fun send(req: Req)
         suspend fun closeAndReceive(): ResponseMessage<Resp>
 

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Closeable.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Closeable.kt
@@ -1,0 +1,43 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.conformance.client.adapt
+
+// Like java.io.Closeable, but the close operation is suspendable.
+interface Closeable {
+    suspend fun close()
+}
+
+// Like the standard kotlin "use" extension function, but uses
+// a suspending Closeable instead of java.io.Closeable and accepts
+// a suspending block.
+internal suspend fun <T : Closeable, R> T.use(block: suspend (T) -> R): R {
+    var exception: Throwable? = null
+    try {
+        return block(this)
+    } catch (ex: Throwable) {
+        exception = ex
+        throw exception
+    } finally {
+        try {
+            this.close()
+        } catch (ex: Throwable) {
+            if (exception != null) {
+                exception.addSuppressed(ex)
+            } else {
+                throw ex
+            }
+        }
+    }
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Invoker.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/Invoker.kt
@@ -17,8 +17,8 @@ package com.connectrpc.conformance.client.adapt
 /**
  * An RPC stub that allows for invoking RPC methods.
  * Each method of Invoker corresponds to an RPC method
- * and returns a client stub that can be used to actually
- * invoke that RPC.
+ * of the conformance service and returns a client
+ * object that can be used to actually invoke that RPC.
  */
 interface Invoker {
     fun unaryClient(): UnaryClient<*, *>

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
@@ -28,7 +28,7 @@ import com.google.protobuf.MessageLite
  * requests "half-closes" the stream; closing the responses
  * "fully closes" it.
  */
-interface RequestStream<Req : MessageLite> : Closeable {
+interface RequestStream<Req : MessageLite> : SuspendCloseable {
     /**
      * Sends a message on the stream.
      * @throws Exception when the request cannot be sent

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/RequestStream.kt
@@ -21,10 +21,20 @@ import com.google.protobuf.MessageLite
  * RequestStream is a stream that allows a client to upload
  * zero or more request messages. When the client is done
  * sending messages, it must close the stream.
+ *
+ * Note that closing the request stream is not strictly
+ * required if the RPC is cancelled or fails prematurely
+ * or if the response stream is closed first. Closing the
+ * requests "half-closes" the stream; closing the responses
+ * "fully closes" it.
  */
-interface RequestStream<Req : MessageLite> {
+interface RequestStream<Req : MessageLite> : Closeable {
+    /**
+     * Sends a message on the stream.
+     * @throws Exception when the request cannot be sent
+     *         because of an error with the streaming call
+     */
     suspend fun send(req: Req)
-    fun close()
 
     companion object {
         fun <Req : MessageLite, Resp : MessageLite> new(underlying: BidirectionalStreamInterface<Req, Resp>): RequestStream<Req> {
@@ -36,7 +46,7 @@ interface RequestStream<Req : MessageLite> {
                     }
                 }
 
-                override fun close() {
+                override suspend fun close() {
                     underlying.sendClose()
                 }
             }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
  *
  * @param Resp The response message type
  */
-interface ResponseStream<Resp : MessageLite> : Closeable {
+interface ResponseStream<Resp : MessageLite> : SuspendCloseable {
     val messages: ReceiveChannel<Resp>
     suspend fun headers(): Headers
     suspend fun trailers(): Headers

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ResponseStream.kt
@@ -29,14 +29,10 @@ import kotlinx.coroutines.channels.ReceiveChannel
  *
  * @param Resp The response message type
  */
-interface ResponseStream<Resp : MessageLite> {
+interface ResponseStream<Resp : MessageLite> : Closeable {
     val messages: ReceiveChannel<Resp>
-
     suspend fun headers(): Headers
-
     suspend fun trailers(): Headers
-
-    fun close()
 
     companion object {
         fun <Req : MessageLite, Resp : MessageLite> new(underlying: BidirectionalStreamInterface<Req, Resp>): ResponseStream<Resp> {
@@ -52,7 +48,7 @@ interface ResponseStream<Resp : MessageLite> {
                     return underlying.responseTrailers().await()
                 }
 
-                override fun close() {
+                override suspend fun close() {
                     underlying.receiveClose()
                 }
             }
@@ -71,7 +67,7 @@ interface ResponseStream<Resp : MessageLite> {
                     return underlying.responseTrailers().await()
                 }
 
-                override fun close() {
+                override suspend fun close() {
                     underlying.receiveClose()
                 }
             }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
@@ -31,3 +31,17 @@ abstract class ServerStreamClient<Req : MessageLite, Resp : MessageLite>(
 ) {
     abstract suspend fun execute(req: Req, headers: Headers): ResponseStream<Resp>
 }
+
+/**
+ * Executes the server-stream call inside the given block. The block
+ * is used to consume the responses. The stream is automatically closed
+ * when the block returns or throws.
+ */
+suspend fun <Req : MessageLite, Resp : MessageLite, R> ServerStreamClient<Req, Resp>.execute(
+    req: Req,
+    headers: Headers,
+    block: suspend (ResponseStream<Resp>) -> R,
+): R {
+    val stream = execute(req, headers)
+    return stream.use(block)
+}

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/SuspendCloseable.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/SuspendCloseable.kt
@@ -15,14 +15,14 @@
 package com.connectrpc.conformance.client.adapt
 
 // Like java.io.Closeable, but the close operation is suspendable.
-interface Closeable {
+interface SuspendCloseable {
     suspend fun close()
 }
 
 // Like the standard kotlin "use" extension function, but uses
 // a suspending Closeable instead of java.io.Closeable and accepts
 // a suspending block.
-internal suspend fun <T : Closeable, R> T.use(block: suspend (T) -> R): R {
+internal suspend fun <T : SuspendCloseable, R> T.use(block: suspend (T) -> R): R {
     var exception: Throwable? = null
     try {
         return block(this)


### PR DESCRIPTION
This is mostly just me riffing on stuff that would be more idiomatic Kotlin.

In particular, this makes the three stream types `Closeable`. They aren't `java.io.Closeable` because I want the close to be suspending function. (Not currently _necessary_, but I think it might be in the future to implement some other ideas I have.)

Anyhow, this also introduces extension functions that let you execute an RPC and use the stream in a block, so that the stream is automatically closed for you. I think that works especially well for the `ServerStream`, which could actually throw _before_ you get back a stream (since it could fail to send the initial request). So, without something like this, it could be gnarly with a separate try/catch on the main invocation and then another try/finally around the stream operations. (Admittedly, most client code probably won't look quite like the conformance client, which is trying to capture a lot of info to package back into response to send to test runner...)

This is still all just in the conformance client. Once we're happy with the shape of the APIs there, I'd like to re-do the actual interfaces in the main connectrpc package. So I consider the internal APIs of the conformance "adapter" package my playground :)

Anyhow, just figured I'd explore a little and see what you think.