### PR TITLE
Makes ResponseStream actually implement ReceiveChannel

### DIFF
--- a/conformance/client/build.gradle.kts
+++ b/conformance/client/build.gradle.kts
@@ -2,6 +2,15 @@ plugins {
     kotlin("jvm")
 }
 
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            // Generated Kotlin code for protobuf uses OptIn annotation
+            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        }
+    }
+}
+
 dependencies {
     implementation(project(":okhttp"))
     implementation(libs.kotlin.coroutines.core)

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -329,7 +329,7 @@ class Client(
                     stream.close()
                 }
                 try {
-                    val resp = stream.responses.messages.receive()
+                    val resp = stream.responses.receive()
                     payloads.add(payloadExtractor(resp))
                     if (cancel is Cancel.AfterNumResponses && cancel.num == payloads.size) {
                         stream.close()
@@ -363,7 +363,7 @@ class Client(
             var connEx: ConnectException? = null
             var trailers: Headers
             try {
-                for (resp in stream.responses.messages) {
+                for (resp in stream.responses) {
                     payloads.add(payloadExtractor(resp))
                     if (cancel is Cancel.AfterNumResponses && cancel.num == payloads.size) {
                         stream.close()
@@ -418,7 +418,7 @@ class Client(
             if (cancel is Cancel.AfterNumResponses && cancel.num == 0) {
                 stream.close()
             }
-            for (resp in stream.messages) {
+            for (resp in stream) {
                 payloads.add(payloadExtractor(resp))
                 if (cancel is Cancel.AfterNumResponses && cancel.num == payloads.size) {
                     stream.close()

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/SuspendCloseable.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/SuspendCloseable.kt
@@ -16,13 +16,18 @@ package com.connectrpc.conformance.client.adapt
 
 // Like java.io.Closeable, but the close operation is suspendable.
 interface SuspendCloseable {
+    // Closes this resource, suspending the current coroutine if
+    // necessary. Suspension is used in case the close operation
+    // needs to do anything blocking, including I/O: in such a
+    // case, the blocking implementation can be executed in a
+    // coroutine context where blocking is appropriate, and the
+    // calling coroutine can resume after it finishes.
     suspend fun close()
 }
 
 // Like the standard kotlin "use" extension function, but uses
-// a suspending Closeable instead of java.io.Closeable and accepts
-// a suspending block.
-internal suspend fun <T : SuspendCloseable, R> T.use(block: suspend (T) -> R): R {
+// a SuspendingCloseable instead of java.io.Closeable.
+suspend inline fun <T : SuspendCloseable, R> T.use(block: (T) -> R): R {
     var exception: Throwable? = null
     try {
         return block(this)


### PR DESCRIPTION
This is a small extension on top of the previous PR (#213).

Instead of response streams having a `messages` property of type `ReceiveChannel`, the `ResponseStream` interface _extends_ `ReceiveChannel`. This just removes a small amount of indirection, hopefully making it easier to use.

This also makes `ClientStream` _extend_ `RequestStream`, since its interface is a strict superset.

Finally, for the use case described by @kohenkatz in that previous PR, about possibly using channels as the way to get data into the request stream, this adds `copyFromChannel` helper functions for client- and bidi-streaming methods.