### PR TITLE
Auto-dispatch to I/O context

### DIFF
--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/TracingHTTPClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/TracingHTTPClient.kt
@@ -97,12 +97,12 @@ internal class TracingHTTPClient(
             return res
         }
 
-        override fun sendClose() {
+        override suspend fun sendClose() {
             printer.printlnWithStackTrace("Half-closing stream")
             delegate.sendClose()
         }
 
-        override fun receiveClose() {
+        override suspend fun receiveClose() {
             printer.printlnWithStackTrace("Closing stream")
             delegate.receiveClose()
         }

--- a/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/com/connectrpc/examples/kotlin/Main.kt
@@ -22,7 +22,6 @@ import com.connectrpc.impl.ProtocolClient
 import com.connectrpc.okhttp.ConnectOkHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import java.time.Duration
 
@@ -44,6 +43,9 @@ class Main {
                     ProtocolClientConfig(
                         host = host,
                         serializationStrategy = GoogleJavaProtobufStrategy(),
+                        // RPC operations that involve network I/O will
+                        // use this coroutine context.
+                        ioCoroutineContext = Dispatchers.IO,
                     ),
                 )
                 val elizaServiceClient = ElizaServiceClient(client)
@@ -57,13 +59,11 @@ class Main {
 
         private suspend fun connectStreaming(elizaServiceClient: ElizaServiceClient) {
             val stream = elizaServiceClient.converse()
-            withContext(Dispatchers.IO) {
-                // Add the message the user is sending to the views.
-                stream.send(converseRequest { sentence = "hello" })
-                stream.sendClose()
-                for (response in stream.responseChannel()) {
-                    println(response.sentence)
-                }
+            // Add the message the user is sending to the views.
+            stream.send(converseRequest { sentence = "hello" })
+            stream.sendClose()
+            for (response in stream.responseChannel()) {
+                println(response.sentence)
             }
         }
     }

--- a/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/BidirectionalStreamInterface.kt
@@ -67,12 +67,12 @@ interface BidirectionalStreamInterface<Input, Output> {
     /**
      * Close the send stream. No calls to [send] are valid after calling [sendClose].
      */
-    fun sendClose()
+    suspend fun sendClose()
 
     /**
      * Close the receive stream.
      */
-    fun receiveClose()
+    suspend fun receiveClose()
 
     /**
      * Determine if the underlying client send stream is closed.

--- a/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ClientOnlyStreamInterface.kt
@@ -57,13 +57,13 @@ interface ClientOnlyStreamInterface<Input, Output> {
     /**
      * Close the stream. No calls to [send] are valid after calling [sendClose].
      */
-    fun sendClose()
+    suspend fun sendClose()
 
     /**
      * Cancels the stream. This closes both send and receive sides of the stream
      * without awaiting any server reply.
      */
-    fun cancel()
+    suspend fun cancel()
 
     /**
      * Determine if the underlying client send stream is closed.

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -48,10 +48,10 @@ class ProtocolClientConfig @JvmOverloads constructor(
     compressionPools: List<CompressionPool> = listOf(GzipCompressionPool),
     // The coroutine context to use for I/O, such as sending RPC messages.
     // If null, the current/calling coroutine context is used. So the caller
-    // may need explicitly dispatch send calls using contexts where I/O is
-    // appropriate (using the withContext extension function). If non-null
-    // (such as Dispatchers.IO), operations that involve I/O pr other
-    // blocking will automatically be dispatched using the biven context,
+    // may need to explicitly dispatch send calls using contexts where I/O
+    // is appropriate (using the withContext extension function). If non-null
+    // (such as Dispatchers.IO), operations that involve I/O or other
+    // blocking will automatically be dispatched using the given context,
     // so the caller does not need to worry about it.
     val ioCoroutineContext: CoroutineContext? = null,
 ) {

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -22,6 +22,7 @@ import com.connectrpc.protocols.GRPCInterceptor
 import com.connectrpc.protocols.GRPCWebInterceptor
 import com.connectrpc.protocols.NetworkProtocol
 import java.net.URI
+import kotlin.coroutines.CoroutineContext
 
 /**
  *  Set of configuration used to set up clients.
@@ -45,6 +46,14 @@ class ProtocolClientConfig @JvmOverloads constructor(
     // Compression pools that provide support for the provided `compressionName`, as well as any
     // other compression methods that need to be supported for inbound responses.
     compressionPools: List<CompressionPool> = listOf(GzipCompressionPool),
+    // The coroutine context to use for I/O, such as sending RPC messages.
+    // If null, the current/calling coroutine context is used. So the caller
+    // may need explicitly dispatch send calls using contexts where I/O is
+    // appropriate (using the withContext extension function). If non-null
+    // (such as Dispatchers.IO), operations that involve I/O pr other
+    // blocking will automatically be dispatched using the biven context,
+    // so the caller does not need to worry about it.
+    val ioCoroutineContext: CoroutineContext? = null,
 ) {
     private val internalInterceptorFactoryList = mutableListOf<(ProtocolClientConfig) -> Interceptor>()
     private val compressionPools = mutableMapOf<String, CompressionPool>()

--- a/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ServerOnlyStreamInterface.kt
@@ -62,7 +62,7 @@ interface ServerOnlyStreamInterface<Input, Output> {
     /**
      * Close the receive stream.
      */
-    fun receiveClose()
+    suspend fun receiveClose()
 
     /**
      * Determine if the underlying client receive stream is closed.

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -16,7 +16,6 @@ package com.connectrpc.http
 
 import com.connectrpc.StreamResult
 import okio.Buffer
-import java.util.concurrent.atomic.AtomicBoolean
 
 typealias Cancelable = () -> Unit
 
@@ -45,93 +44,4 @@ interface HTTPClientInterface {
      * @return The created stream.
      */
     fun stream(request: HTTPRequest, duplex: Boolean, onResult: suspend (StreamResult<Buffer>) -> Unit): Stream
-}
-
-interface Stream {
-    suspend fun send(buffer: Buffer): Result<Unit>
-
-    fun sendClose()
-
-    fun receiveClose()
-
-    fun isSendClosed(): Boolean
-
-    fun isReceiveClosed(): Boolean
-}
-
-fun Stream(
-    onSend: suspend (Buffer) -> Result<Unit>,
-    onSendClose: () -> Unit = {},
-    onReceiveClose: () -> Unit = {},
-): Stream {
-    val isSendClosed = AtomicBoolean()
-    val isReceiveClosed = AtomicBoolean()
-    return object : Stream {
-        override suspend fun send(buffer: Buffer): Result<Unit> {
-            if (isSendClosed()) {
-                return Result.failure(IllegalStateException("cannot send. underlying stream is closed"))
-            }
-            return try {
-                onSend(buffer)
-            } catch (e: Throwable) {
-                Result.failure(e)
-            }
-        }
-
-        override fun sendClose() {
-            if (isSendClosed.compareAndSet(false, true)) {
-                onSendClose()
-            }
-        }
-
-        override fun receiveClose() {
-            if (isReceiveClosed.compareAndSet(false, true)) {
-                try {
-                    onReceiveClose()
-                } finally {
-                    // When receive side is closed, the send side is
-                    // implicitly closed as well.
-                    // We don't use sendClose() because we don't want to
-                    // invoke onSendClose() since that will try to actually
-                    // half-close the HTTP stream, which will fail since
-                    // closing the receive side cancels the entire thing.
-                    isSendClosed.set(true)
-                }
-            }
-        }
-
-        override fun isSendClosed(): Boolean {
-            return isSendClosed.get()
-        }
-
-        override fun isReceiveClosed(): Boolean {
-            return isReceiveClosed.get()
-        }
-    }
-}
-
-/**
- * Returns a new stream that applies the given function to each
- * buffer when send is called. The result of that function is
- * what is passed along to the original stream.
- */
-fun Stream.transform(apply: (Buffer) -> Buffer): Stream {
-    val delegate = this
-    return object : Stream {
-        override suspend fun send(buffer: Buffer): Result<Unit> {
-            return delegate.send(apply(buffer))
-        }
-        override fun sendClose() {
-            delegate.sendClose()
-        }
-        override fun receiveClose() {
-            delegate.receiveClose()
-        }
-        override fun isSendClosed(): Boolean {
-            return delegate.isSendClosed()
-        }
-        override fun isReceiveClosed(): Boolean {
-            return delegate.isReceiveClosed()
-        }
-    }
 }

--- a/library/src/main/kotlin/com/connectrpc/http/Stream.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/Stream.kt
@@ -1,0 +1,145 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.http
+
+import kotlinx.coroutines.withContext
+import okio.Buffer
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Stream represents the communications for a single streaming RPC.
+ * It can be used to send messages and to close the stream. Receiving
+ * messages is done via callbacks provided when the stream is created.
+ *
+ * See HTTPClientInterface#stream.
+ */
+interface Stream {
+    suspend fun send(buffer: Buffer): Result<Unit>
+
+    suspend fun sendClose()
+
+    suspend fun receiveClose()
+
+    fun isSendClosed(): Boolean
+
+    fun isReceiveClosed(): Boolean
+}
+
+/**
+ * Creates a new stream whose implementation of sending and
+ * closing is delegated to the given lambdas.
+ */
+fun Stream(
+    onSend: suspend (Buffer) -> Result<Unit>,
+    onSendClose: suspend () -> Unit = {},
+    onReceiveClose: suspend () -> Unit = {},
+): Stream {
+    val isSendClosed = AtomicBoolean()
+    val isReceiveClosed = AtomicBoolean()
+    return object : Stream {
+        override suspend fun send(buffer: Buffer): Result<Unit> {
+            if (isSendClosed()) {
+                return Result.failure(IllegalStateException("cannot send. underlying stream is closed"))
+            }
+            return try {
+                onSend(buffer)
+            } catch (e: Throwable) {
+                Result.failure(e)
+            }
+        }
+
+        override suspend fun sendClose() {
+            if (isSendClosed.compareAndSet(false, true)) {
+                onSendClose()
+            }
+        }
+
+        override suspend fun receiveClose() {
+            if (isReceiveClosed.compareAndSet(false, true)) {
+                try {
+                    onReceiveClose()
+                } finally {
+                    // When receive side is closed, the send side is
+                    // implicitly closed as well.
+                    // We don't use sendClose() because we don't want to
+                    // invoke onSendClose() since that will try to actually
+                    // half-close the HTTP stream, which will fail since
+                    // closing the receive side cancels the entire thing.
+                    isSendClosed.set(true)
+                }
+            }
+        }
+
+        override fun isSendClosed(): Boolean {
+            return isSendClosed.get()
+        }
+
+        override fun isReceiveClosed(): Boolean {
+            return isReceiveClosed.get()
+        }
+    }
+}
+
+/**
+ * Returns a new stream that applies the given function to each
+ * buffer when send is called. The result of that function is
+ * what is passed along to the original stream.
+ */
+fun Stream.transform(apply: (Buffer) -> Buffer): Stream {
+    val delegate = this
+    return object : Stream {
+        override suspend fun send(buffer: Buffer): Result<Unit> {
+            return delegate.send(apply(buffer))
+        }
+        override suspend fun sendClose() {
+            delegate.sendClose()
+        }
+        override suspend fun receiveClose() {
+            delegate.receiveClose()
+        }
+        override fun isSendClosed(): Boolean {
+            return delegate.isSendClosed()
+        }
+        override fun isReceiveClosed(): Boolean {
+            return delegate.isReceiveClosed()
+        }
+    }
+}
+
+/**
+ * Returns a new stream that dispatches suspending operations
+ * (sending and closing) using the given coroutine context.
+ */
+fun Stream.dispatchIn(context: CoroutineContext): Stream {
+    val delegate = this
+    return object : Stream {
+        override suspend fun send(buffer: Buffer): Result<Unit> = withContext(context) {
+            delegate.send(buffer)
+        }
+        override suspend fun sendClose() = withContext(context) {
+            delegate.sendClose()
+        }
+        override suspend fun receiveClose() = withContext(context) {
+            delegate.receiveClose()
+        }
+        override fun isSendClosed(): Boolean {
+            return delegate.isSendClosed()
+        }
+        override fun isReceiveClosed(): Boolean {
+            return delegate.isReceiveClosed()
+        }
+    }
+}

--- a/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/BidirectionalStream.kt
@@ -59,11 +59,11 @@ internal class BidirectionalStream<Input, Output>(
         return stream.isReceiveClosed()
     }
 
-    override fun sendClose() {
+    override suspend fun sendClose() {
         stream.sendClose()
     }
 
-    override fun receiveClose() {
+    override suspend fun receiveClose() {
         stream.receiveClose()
     }
 

--- a/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ClientOnlyStream.kt
@@ -54,11 +54,11 @@ internal class ClientOnlyStream<Input, Output>(
         return messageStream.responseTrailers()
     }
 
-    override fun sendClose() {
+    override suspend fun sendClose() {
         return messageStream.sendClose()
     }
 
-    override fun cancel() {
+    override suspend fun cancel() {
         return messageStream.receiveClose()
     }
 

--- a/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ServerOnlyStream.kt
@@ -46,7 +46,7 @@ internal class ServerOnlyStream<Input, Output>(
         }
     }
 
-    override fun receiveClose() {
+    override suspend fun receiveClose() {
         messageStream.receiveClose()
     }
 


### PR DESCRIPTION
This adds a new property to `ProtocolClientConfig` called `ioCoroutineContext`. It defaults to null, which means there is no change in behavior from the current defaults -- operations happen in the calling coroutine context, so callers of RPC methods must handle the dispatch.

But when it is configured as non-null (most likely using a value like `Dispatchers.IO`), then I/O and blocking operations for an RPC are automatically dispatched to the given coroutine context. This allows for RPC client code to be used from any coroutine context without having to worry about explicitly dispatching.