### PR TITLE
Denormalize "Code", slight simplification of HTTP interface

### DIFF
--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -386,9 +386,6 @@ class Client(
     private fun unaryResult(numUnsent: Int, result: ResponseMessage<out MessageLite>): ClientResponseResult {
         return when (result) {
             is ResponseMessage.Success -> {
-                if (result.code != Code.OK) {
-                    throw RuntimeException("RPC was successful but ended with non-OK code ${result.code}")
-                }
                 ClientResponseResult(
                     headers = result.headers,
                     payloads = listOf(payloadExtractor(result.message)),
@@ -397,9 +394,6 @@ class Client(
                 )
             }
             is ResponseMessage.Failure -> {
-                if (result.code != result.cause.code) {
-                    throw RuntimeException("RPC result has mismatching codes: ${result.code} != ${result.cause.code}")
-                }
                 ClientResponseResult(
                     headers = result.headers,
                     error = result.cause,

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
@@ -96,7 +96,6 @@ abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
                             val resp = underlying.receiveAndClose()
                             return ResponseMessage.Success(
                                 message = resp,
-                                code = Code.OK,
                                 headers = underlying.responseHeaders().await(),
                                 trailers = underlying.responseTrailers().await(),
                             )
@@ -108,7 +107,6 @@ abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
                             }
                             return ResponseMessage.Failure(
                                 cause = connectException,
-                                code = connectException.code,
                                 headers = underlying.responseHeaders().await(),
                                 trailers = connectException.metadata,
                             )

--- a/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
+++ b/conformance/google-javalite/src/test/kotlin/com/connectrpc/conformance/javalite/ConformanceTest.kt
@@ -16,6 +16,7 @@ package com.connectrpc.conformance.javalite
 
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
+import com.connectrpc.ResponseMessage
 import com.connectrpc.conformance.BaseConformanceTest
 import com.connectrpc.conformance.ServerType
 import com.connectrpc.conformance.v1.ErrorDetail
@@ -199,7 +200,6 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unaryCall(message, headers) { response ->
-            assertThat(response.code).isEqualTo(Code.OK)
             assertThat(response.headers[leadingKey]).containsExactly(leadingValue)
             assertThat(response.trailers[trailingKey]).containsExactly(b64Encode(trailingValue))
             response.failure {
@@ -224,10 +224,9 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unaryCall(message) { response ->
-            assertThat(response.code).isEqualTo(Code.UNKNOWN)
             response.failure { errorResponse ->
                 assertThat(errorResponse.cause).isNotNull()
-                assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
+                assertThat(errorResponse.cause.code).isEqualTo(Code.UNKNOWN)
                 assertThat(errorResponse.cause.message).isEqualTo("test status message")
                 countDownLatch.countDown()
             }
@@ -292,7 +291,6 @@ class ConformanceTest(
             response.failure { errorResponse ->
                 val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.UNKNOWN)
-                assertThat(response.code).isEqualTo(Code.UNKNOWN)
                 assertThat(error.message).isEqualTo(statusMessage)
                 countDownLatch.countDown()
             }
@@ -308,7 +306,8 @@ class ConformanceTest(
     fun unimplementedMethod(): Unit = runBlocking {
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unimplementedCall(empty {}) { response ->
-            assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+            assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+            response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
             countDownLatch.countDown()
         }
         countDownLatch.await(500, TimeUnit.MILLISECONDS)
@@ -319,7 +318,8 @@ class ConformanceTest(
     fun unimplementedService(): Unit = runBlocking {
         val countDownLatch = CountDownLatch(1)
         unimplementedServiceClient.unimplementedCall(empty {}) { response ->
-            assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+            assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+            response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
             countDownLatch.countDown()
         }
         countDownLatch.await(500, TimeUnit.MILLISECONDS)
@@ -356,7 +356,6 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.failUnaryCall(simpleRequest {}) { response ->
-            assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
             response.failure { errorResponse ->
                 val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
@@ -419,7 +418,6 @@ class ConformanceTest(
             payload = payload { body = ByteString.copyFrom(ByteArray(size)) }
         }
         val response = testServiceConnectClient.unaryCallBlocking(message, headers).execute()
-        assertThat(response.code).isEqualTo(Code.OK)
         assertThat(response.headers[leadingKey]).containsExactly(leadingValue)
         assertThat(response.trailers[trailingKey]).containsExactly(b64Encode(trailingValue))
         response.failure {
@@ -439,10 +437,9 @@ class ConformanceTest(
             }
         }
         val response = testServiceConnectClient.unaryCallBlocking(message).execute()
-        assertThat(response.code).isEqualTo(Code.UNKNOWN)
         response.failure { errorResponse ->
             assertThat(errorResponse.cause).isNotNull()
-            assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
+            assertThat(errorResponse.cause.code).isEqualTo(Code.UNKNOWN)
             assertThat(errorResponse.cause.message).isEqualTo("test status message")
         }
         response.success {
@@ -465,7 +462,6 @@ class ConformanceTest(
         response.failure { errorResponse ->
             val error = errorResponse.cause
             assertThat(error.code).isEqualTo(Code.UNKNOWN)
-            assertThat(response.code).isEqualTo(Code.UNKNOWN)
             assertThat(error.message).isEqualTo(statusMessage)
         }
         response.success {
@@ -476,13 +472,15 @@ class ConformanceTest(
     @Test
     fun unimplementedMethodBlocking(): Unit = runBlocking {
         val response = testServiceConnectClient.unimplementedCallBlocking(empty {}).execute()
-        assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+        assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
     }
 
     @Test
     fun unimplementedServiceBlocking(): Unit = runBlocking {
         val response = unimplementedServiceClient.unimplementedCallBlocking(empty {}).execute()
-        assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+        assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
     }
 
     @Test
@@ -492,7 +490,6 @@ class ConformanceTest(
             domain = "connect-conformance"
         }
         val response = testServiceConnectClient.failUnaryCallBlocking(simpleRequest {}).execute()
-        assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
         response.failure { errorResponse ->
             val error = errorResponse.cause
             assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
@@ -562,7 +559,6 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unaryCall(message, headers) { response ->
-            assertThat(response.code).isEqualTo(Code.OK)
             assertThat(response.headers[leadingKey]).containsExactly(leadingValue)
             assertThat(response.trailers[trailingKey]).containsExactly(b64Encode(trailingValue))
             response.failure {
@@ -587,10 +583,9 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unaryCall(message) { response ->
-            assertThat(response.code).isEqualTo(Code.UNKNOWN)
             response.failure { errorResponse ->
                 assertThat(errorResponse.cause).isNotNull()
-                assertThat(errorResponse.code).isEqualTo(Code.UNKNOWN)
+                assertThat(errorResponse.cause.code).isEqualTo(Code.UNKNOWN)
                 assertThat(errorResponse.cause.message).isEqualTo("test status message")
                 countDownLatch.countDown()
             }
@@ -619,7 +614,6 @@ class ConformanceTest(
             response.failure { errorResponse ->
                 val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.UNKNOWN)
-                assertThat(response.code).isEqualTo(Code.UNKNOWN)
                 assertThat(error.message).isEqualTo(statusMessage)
                 countDownLatch.countDown()
             }
@@ -635,7 +629,8 @@ class ConformanceTest(
     fun unimplementedMethodCallback(): Unit = runBlocking {
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.unimplementedCall(empty {}) { response ->
-            assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+            assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+            response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
             countDownLatch.countDown()
         }
         countDownLatch.await(500, TimeUnit.MILLISECONDS)
@@ -646,7 +641,8 @@ class ConformanceTest(
     fun unimplementedServiceCallback(): Unit = runBlocking {
         val countDownLatch = CountDownLatch(1)
         unimplementedServiceClient.unimplementedCall(empty {}) { response ->
-            assertThat(response.code).isEqualTo(Code.UNIMPLEMENTED)
+            assertThat(response).isInstanceOf(ResponseMessage.Failure::class.java)
+            response.failure { assertThat(it.cause.code).isEqualTo(Code.UNIMPLEMENTED) }
             countDownLatch.countDown()
         }
         countDownLatch.await(500, TimeUnit.MILLISECONDS)
@@ -661,7 +657,6 @@ class ConformanceTest(
         }
         val countDownLatch = CountDownLatch(1)
         testServiceConnectClient.failUnaryCall(simpleRequest {}) { response ->
-            assertThat(response.code).isEqualTo(Code.RESOURCE_EXHAUSTED)
             response.failure { errorResponse ->
                 val error = errorResponse.cause
                 assertThat(error.code).isEqualTo(Code.RESOURCE_EXHAUSTED)

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
@@ -110,11 +110,3 @@ interface ProtocolClientInterface {
         methodSpec: MethodSpec<Input, Output>,
     ): ClientOnlyStreamInterface<Input, Output>
 }
-
-fun Headers.toLowercase(): Headers {
-    return asSequence().groupingBy {
-        it.key.lowercase()
-    }.aggregate { _: String, accumulator: List<String>?, element: Map.Entry<String, List<String>>, _: Boolean ->
-        accumulator?.plus(element.value) ?: element.value
-    }
-}

--- a/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
+++ b/library/src/main/kotlin/com/connectrpc/ResponseMessage.kt
@@ -18,12 +18,6 @@ package com.connectrpc
  * Typed unary response from an RPC.
  */
 sealed class ResponseMessage<Output>(
-    // TODO: remove code as its redundant with the code inside of
-    //       ConnectException in the error case and is always OK
-    //       in the success case.
-
-    // The status code of the response.
-    open val code: Code,
     // Response headers specified by the server.
     open val headers: Headers,
     // Trailers provided by the server.
@@ -32,30 +26,26 @@ sealed class ResponseMessage<Output>(
     class Success<Output>(
         // The message.
         val message: Output,
-        // The status code of the response.
-        override val code: Code,
         // Response headers specified by the server.
-        override val headers: Headers,
+        headers: Headers,
         // Trailers provided by the server.
-        override val trailers: Trailers,
-    ) : ResponseMessage<Output>(code, headers, trailers) {
+        trailers: Trailers,
+    ) : ResponseMessage<Output>(headers, trailers) {
         override fun toString(): String {
-            return "Success{message=$message,code=$code,headers=$headers,trailers=$trailers}"
+            return "Success{message=$message,headers=$headers,trailers=$trailers}"
         }
     }
 
     class Failure<Output>(
         // The problem.
         val cause: ConnectException,
-        // The status code of the response.
-        override val code: Code,
         // Response headers specified by the server.
-        override val headers: Headers,
+        headers: Headers,
         // Trailers provided by the server.
-        override val trailers: Trailers,
-    ) : ResponseMessage<Output>(code, headers, trailers) {
+        trailers: Trailers,
+    ) : ResponseMessage<Output>(headers, trailers) {
         override fun toString(): String {
-            return "Failure{cause=$cause,code=$code,headers=$headers,trailers=$trailers}"
+            return "Failure{cause=$cause,headers=$headers,trailers=$trailers}"
         }
     }
 

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -35,16 +35,9 @@ sealed class StreamResult<Output> {
     }
 
     // Stream is complete. Provides the end status code and optionally an error and trailers.
-    class Complete<Output>(val code: Code, val cause: Throwable? = null, val trailers: Trailers = emptyMap()) : StreamResult<Output>() {
-        /**
-         * Get the ConnectException from the result.
-         *
-         * @return The [ConnectException] if present, null otherwise.
-         */
-        fun connectException() = cause as? ConnectException
-
+    class Complete<Output>(val cause: ConnectException? = null, val trailers: Trailers = emptyMap()) : StreamResult<Output>() {
         override fun toString(): String {
-            return "Complete{code=$code,cause=$cause,trailers=$trailers}"
+            return "Complete{cause=$cause,trailers=$trailers}"
         }
     }
 
@@ -55,7 +48,7 @@ sealed class StreamResult<Output> {
      * @param onMessage Transform a Message result.
      * @param onCompletion Transform a Completion result.
      */
-    fun <Result> fold(
+    inline fun <Result> fold(
         onHeaders: (Headers<Output>) -> Result,
         onMessage: (Message<Output>) -> Result,
         onCompletion: (Complete<Output>) -> Result,
@@ -71,22 +64,5 @@ sealed class StreamResult<Output> {
                 onCompletion(this)
             }
         }
-    }
-
-    /**
-     * Fold the different results into a nullable single type.
-     * Unlike `fold`, the caller can omit some transformations,
-     * which default to returning null.
-     *
-     * @param onHeaders Transform a Header result.
-     * @param onMessage Transform a Message result.
-     * @param onCompletion Transform a Completion result.
-     */
-    fun <Result> maybeFold(
-        onHeaders: (Headers<Output>) -> Result? = { null },
-        onMessage: (Message<Output>) -> Result? = { null },
-        onCompletion: (Complete<Output>) -> Result? = { null },
-    ): Result? {
-        return fold(onHeaders, onMessage, onCompletion)
     }
 }

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPResponse.kt
@@ -14,7 +14,6 @@
 
 package com.connectrpc.http
 
-import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.Trailers
@@ -24,19 +23,43 @@ import okio.BufferedSource
  * Unary HTTP response received from the server.
  */
 class HTTPResponse(
-    // The status code of the response.
-    val code: Code,
+    // The underlying http status code. If null,
+    // no response was ever received on the network
+    // and cause must be non-null.
+    val status: Int?,
     // Response headers specified by the server.
     val headers: Headers,
     // Body data provided by the server.
     val message: BufferedSource,
     // Trailers provided by the server.
     val trailers: Trailers,
-    // Tracing information that can be used for logging or debugging network-level details.
-    // This information is expected to change when switching protocols (i.e., from Connect to
-    // gRPC-Web), as each protocol has different HTTP semantics.
-    // null in cases where no response was received from the server.
-    val tracingInfo: TracingInfo?,
-    // The accompanying error, if the request failed.
+    // The accompanying exception, if the request failed.
     val cause: ConnectException? = null,
 )
+
+/**
+ * Clones the [HTTPResponse] with override values.
+ *
+ * Intended to make mutations for [HTTPResponse] safe for
+ * [com.connectrpc.Interceptor] implementation.
+ */
+fun HTTPResponse.clone(
+    // The status code of the response.
+    status: Int? = this.status,
+    // Response headers specified by the server.
+    headers: Headers = this.headers,
+    // Body data provided by the server.
+    message: BufferedSource = this.message,
+    // Trailers provided by the server.
+    trailers: Trailers = this.trailers,
+    // The accompanying error, if the request failed.
+    cause: ConnectException? = this.cause,
+): HTTPResponse {
+    return HTTPResponse(
+        status,
+        headers,
+        message,
+        trailers,
+        cause,
+    )
+}

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCErrorDetailParserTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCErrorDetailParserTest.kt
@@ -38,8 +38,9 @@ class GRPCErrorDetailParserTest {
                 GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64()),
             ),
         )
-        assertThat(completion!!.code).isEqualTo(Code.UNAUTHENTICATED)
-        assertThat(completion.message.utf8()).isEqualTo("str")
+        assertThat(completion.present).isTrue()
+        assertThat(completion.code).isEqualTo(Code.UNAUTHENTICATED)
+        assertThat(completion.message).isEqualTo("str")
         verify(errorDetailParser).parseDetails("data".commonAsUtf8ToByteArray())
     }
 
@@ -53,7 +54,7 @@ class GRPCErrorDetailParserTest {
                 GRPC_STATUS_DETAILS_TRAILERS to listOf("data".encodeUtf8().base64()),
             ),
         )
-        assertThat(completion).isNull()
+        assertThat(completion.present).isFalse()
     }
 
     @Test
@@ -66,7 +67,8 @@ class GRPCErrorDetailParserTest {
             ),
             trailers = emptyMap(),
         )
-        assertThat(completion!!.code).isEqualTo(Code.UNAUTHENTICATED)
+        assertThat(completion.present).isTrue()
+        assertThat(completion.code).isEqualTo(Code.UNAUTHENTICATED)
     }
 
     @Test
@@ -79,6 +81,7 @@ class GRPCErrorDetailParserTest {
                 GRPC_MESSAGE_TRAILER to listOf("str"),
             ),
         )
-        assertThat(completion!!.errorDetails).isEmpty()
+        assertThat(completion.present).isTrue()
+        assertThat(completion.errorDetails).isEmpty()
     }
 }

--- a/okhttp/src/test/kotlin/com/connectrpc/okhttp/MockWebServerTests.kt
+++ b/okhttp/src/test/kotlin/com/connectrpc/okhttp/MockWebServerTests.kt
@@ -17,6 +17,7 @@ package com.connectrpc.okhttp
 import com.connectrpc.Code
 import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.RequestCompression
+import com.connectrpc.ResponseMessage
 import com.connectrpc.SerializationStrategy
 import com.connectrpc.compression.GzipCompressionPool
 import com.connectrpc.eliza.v1.ElizaServiceClient
@@ -55,7 +56,8 @@ class MockWebServerTests {
         mockWebServerRule.server.takeRequest().apply {
             assertThat(path).isEqualTo("/connectrpc.eliza.v1.ElizaService/Say")
         }
-        assertThat(response.code).isEqualTo(Code.INTERNAL_ERROR)
+        assertThat(response).isInstanceOf(ResponseMessage::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.INTERNAL_ERROR) }
     }
 
     @Test
@@ -72,7 +74,8 @@ class MockWebServerTests {
         mockWebServerRule.server.takeRequest().apply {
             assertThat(path).isEqualTo("/connectrpc.eliza.v1.ElizaService/Say")
         }
-        assertThat(response.code).isEqualTo(Code.INTERNAL_ERROR)
+        assertThat(response).isInstanceOf(ResponseMessage::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.INTERNAL_ERROR) }
     }
 
     @Test
@@ -89,7 +92,8 @@ class MockWebServerTests {
         mockWebServerRule.server.takeRequest().apply {
             assertThat(path).isEqualTo("/connectrpc.eliza.v1.ElizaService/Say")
         }
-        assertThat(response.code).isEqualTo(Code.INTERNAL_ERROR)
+        assertThat(response).isInstanceOf(ResponseMessage::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.INTERNAL_ERROR) }
     }
 
     @Test
@@ -106,7 +110,8 @@ class MockWebServerTests {
         mockWebServerRule.server.takeRequest().apply {
             assertThat(path).isEqualTo("/connectrpc.eliza.v1.ElizaService/Say")
         }
-        assertThat(response.code).isEqualTo(Code.INTERNAL_ERROR)
+        assertThat(response).isInstanceOf(ResponseMessage::class.java)
+        response.failure { assertThat(it.cause.code).isEqualTo(Code.INTERNAL_ERROR) }
     }
 
     private fun createClient(serializationStrategy: SerializationStrategy = GoogleJavaProtobufStrategy()): ElizaServiceClient {


### PR DESCRIPTION
Sorry that this is kind of a large PR. The main intent was the first bullet, but I tackled some other things that I think are improvements along the way.

1. This denormalizes the presence of code. It was previously present both on `StreamResult.Complete` and `ResponseMessage`, even though it was redundant with the code on any non-null `ConnectException`.
2. Removes `Code.OK`. It is now just an error code. An "OK" result is easily distinguished by the lack of an exception.
3. The `HTTPClientInterface` was previously responsible for translating HTTP status -> `Code` and the `HTTPResponse` reported back the status in an optional "trace info" field. But translating status to `Code` should be the responsibility of the protocol implementations, not the HTTP client. (Though it is still up to the HTTP client to classify exceptions that prevent an HTTP response from being received, as these could be client-implementation-specific exception types). So this change promotes the status code out of trace info and into the `HTTPResponse`. 
4. `ProtocolClient.stream` used `suspendCancellableCoroutine` incorrectly. It looks like it was trying to associate the stream with the coroutine, so if the coroutine is cancelled then the stream is closed. But it is only effective *while that method is running*, which is almost none at all since it immediately returns a result (no suspensions).

There are some other small clean-ups in here, too, like moving some things around to places that (IMO) make more sense.