### PR TITLE
Fix release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lintfix: ## Applies the lint changes.
 .PHONY: release
 release: generate ## Upload artifacts to Sonatype Nexus.
 	./gradlew $(GRADLE_ARGS) --info publish --stacktrace --no-daemon --no-parallel
-	./gradlew $(GRADLE_ARGS) --info closeAndReleaseRepository
+	./gradlew $(GRADLE_ARGS) --info releaseRepository
 
 .PHONY: releaselocal
 releaselocal: ## Release artifacts to local maven repository.


### PR DESCRIPTION
The latest gradle-maven-publish-plugin has changed the task from 'closeAndReleaseRepository' to 'releaseRepository'.

<!-- **Before submitting your PR:** Please read through the contribution guide at https://github.com/connectrpc/connect-kotlin/blob/main/.github/CONTRIBUTING.md -->
