### PR TITLE
Update to rc4 of conformance suite and fix several issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN := .tmp/bin
 CACHE := .tmp/cache
 LICENSE_HEADER_YEAR_RANGE := 2022-2023
 LICENSE_HEADER_VERSION := v1.30.0
-CONFORMANCE_VERSION := v1.0.0-rc3
+CONFORMANCE_VERSION := v1.0.0-rc4
 PROTOC_VERSION ?= 26.1
 GRADLE_ARGS ?=
 PROTOC := $(BIN)/protoc
@@ -43,34 +43,34 @@ clean: ## Cleans the underlying build.
 runconformance: generate $(CONNECT_CONFORMANCE) ## Run the new conformance test suite.
 	./gradlew $(GRADLE_ARGS) conformance:client:google-java:installDist conformance:client:google-javalite:installDist
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style suspend
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style callback
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style blocking
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style suspend
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style callback
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
+		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style blocking
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-stream-config.yaml \
-		--known-failing @conformance/client/known-failing-stream-cases.txt -- \
+		--known-failing @conformance/client/known-failing-stream-cases.txt --trace -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite
 	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-stream-config.yaml \
-		--known-failing @conformance/client/known-failing-stream-cases.txt -- \
+		--known-failing @conformance/client/known-failing-stream-cases.txt --trace -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java
 
 ifeq ($(UNAME_OS),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PROTOC_VERSION ?= 26.1
 GRADLE_ARGS ?=
 PROTOC := $(BIN)/protoc
 CONNECT_CONFORMANCE := $(BIN)/connectconformance
+CONNECT_CONFORMANCE_ARGS ?= -v --mode client --trace
 
 UNAME_OS := $(shell uname -s)
 UNAME_ARCH := $(shell uname -m)
@@ -42,35 +43,35 @@ clean: ## Cleans the underlying build.
 .PHONY: runconformance
 runconformance: generate $(CONNECT_CONFORMANCE) ## Run the new conformance test suite.
 	./gradlew $(GRADLE_ARGS) conformance:client:google-java:installDist conformance:client:google-javalite:installDist
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/lite-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style suspend
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/lite-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style callback
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/lite-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite \
 		--style blocking
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/standard-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style suspend
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/standard-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style callback
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-unary-config.yaml \
-		--known-failing @conformance/client/known-failing-unary-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/standard-unary-config.yaml \
+		--known-failing @conformance/client/known-failing-unary-cases.txt -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java \
 		--style blocking
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/lite-stream-config.yaml \
-		--known-failing @conformance/client/known-failing-stream-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/lite-stream-config.yaml \
+		--known-failing @conformance/client/known-failing-stream-cases.txt -- \
 		conformance/client/google-javalite/build/install/google-javalite/bin/google-javalite
-	$(CONNECT_CONFORMANCE) -v --mode client --conf conformance/client/standard-stream-config.yaml \
-		--known-failing @conformance/client/known-failing-stream-cases.txt --trace -- \
+	$(CONNECT_CONFORMANCE) $(CONNECT_CONFORMANCE_ARGS) --conf conformance/client/standard-stream-config.yaml \
+		--known-failing @conformance/client/known-failing-stream-cases.txt -- \
 		conformance/client/google-java/build/install/google-java/bin/google-java
 
 ifeq ($(UNAME_OS),Darwin)

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
@@ -251,7 +251,7 @@ class JavaHelpers {
     }
 
     private class TlsCredsImpl(
-        private val msg: com.connectrpc.conformance.v1.ClientCompatRequest.TLSCreds,
+        private val msg: com.connectrpc.conformance.v1.TLSCreds,
     ) : TlsCreds {
         override val cert: ByteString
             get() = msg.cert

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteHelpers.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteHelpers.kt
@@ -233,7 +233,7 @@ class JavaLiteHelpers {
     }
 
     private class TlsCredsImpl(
-        private val msg: com.connectrpc.conformance.v1.ClientCompatRequest.TLSCreds,
+        private val msg: com.connectrpc.conformance.v1.TLSCreds,
     ) : TlsCreds {
         override val cert: ByteString
             get() = msg.cert

--- a/conformance/client/known-failing-unary-cases.txt
+++ b/conformance/client/known-failing-unary-cases.txt
@@ -1,32 +1,13 @@
-# If error body is JSON null, it is interpreted as an unknown error
-# instead of falling back to basing code on the HTTP status.
-Connect Error and End-Stream/**/error/null
-
 # Deadline headers are not currently set.
 Deadline Propagation/**
 
-# This response doesn't look like a normal Connect response, so it
-# goes through okhttp's default 408 code handling, which retries.
-# The retry triggers an error:
-#     client sent another request (#2) for the same test case
-HTTP to Connect Code Mapping/**/request-timeout
-
 # Bug: response content-type is not correctly checked
-Unexpected Responses/**/unexpected-content-type
+**/unexpected-content-type
 
 # Bug: "trailers-only" responses are not correctly identified.
 # If headers contain "grpc-status", this client assumes it is a
 # trailers-only response. However, a trailers-only response should
 # instead be identified by lack of body or HTTP trailers.
 gRPC Unexpected Responses/**/trailers-only/*
+gRPC-Web Unexpected Responses/**/trailers-only/ignore-header-if-body-present
 
-# Bug: if gRPC unary response contains zero messages or
-# more than one message, client does not complain if
-# status trailers says "ok"
-gRPC Unexpected Responses/**/unary-multiple-responses
-gRPC Unexpected Responses/**/unary-ok-but-no-response
-gRPC-Web Unexpected Responses/**/unary-ok-but-no-response
-
-# Bug: incorrect code attribution for these failures (INTERNAL instead of UNKNOWN)
-gRPC-Web Unexpected Responses/**/missing-status
-gRPC-Web Unexpected Responses/**/trailers-in-body/unary-multiple-responses

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -385,10 +385,15 @@ class Client(
                 )
             }
             is ResponseMessage.Failure -> {
+                // TODO: report result.headers and result.trailers independently
+                //       once reference server can report send them independently.
+                //       https://github.com/connectrpc/conformance/pull/840.
+                // Until then, always report trailers as exception metadata (which
+                // may include headers).
                 ClientResponseResult(
                     headers = result.headers,
                     error = result.cause,
-                    trailers = result.trailers,
+                    trailers = result.cause.metadata,
                     numUnsentRequests = numUnsent,
                 )
             }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
@@ -103,7 +103,7 @@ abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
                             return ResponseMessage.Failure(
                                 cause = connEx,
                                 headers = underlying.responseHeaders().await(),
-                                trailers = connEx.metadata,
+                                trailers = underlying.responseTrailers().await(),
                             )
                         }
                     }

--- a/library/src/main/kotlin/com/connectrpc/Code.kt
+++ b/library/src/main/kotlin/com/connectrpc/Code.kt
@@ -47,32 +47,24 @@ enum class Code(val codeName: String, val value: Int) {
         fun fromHTTPStatus(status: Int?): Code {
             return when (status) {
                 null -> UNKNOWN
-                400 -> INVALID_ARGUMENT
+                400 -> INTERNAL_ERROR
                 401 -> UNAUTHENTICATED
                 403 -> PERMISSION_DENIED
                 404 -> UNIMPLEMENTED
-                408 -> DEADLINE_EXCEEDED
-                409 -> ABORTED
-                412 -> FAILED_PRECONDITION
-                413 -> RESOURCE_EXHAUSTED
-                415 -> INTERNAL_ERROR
-                429 -> UNAVAILABLE
-                431 -> RESOURCE_EXHAUSTED
-                499 -> CANCELED
-                502, 503, 504 -> UNAVAILABLE
+                429, 502, 503, 504 -> UNAVAILABLE
                 else -> UNKNOWN
             }
         }
-        fun fromName(name: String?): Code {
+        fun fromName(name: String?, ifNotKnown: Code = UNKNOWN): Code {
             if (name == null) {
-                return UNKNOWN
+                return ifNotKnown
             }
             for (value in values()) {
                 if (value.codeName == name) {
                     return value
                 }
             }
-            return UNKNOWN
+            return ifNotKnown
         }
         fun fromValue(value: Int?): Code? {
             if (value == null) {

--- a/library/src/main/kotlin/com/connectrpc/ConnectErrorDetail.kt
+++ b/library/src/main/kotlin/com/connectrpc/ConnectErrorDetail.kt
@@ -16,14 +16,16 @@ package com.connectrpc
 
 import okio.ByteString
 
-// An ErrorDetail is a self-describing Protobuf message attached to an [*Error].
+// A ConnectErrorDetail is a self-describing Protobuf message attached to a
+// [ConnectException].
+//
 // Error details are sent over the network to clients, which can then work with
 // strongly-typed data rather than trying to parse a complex error message. For
 // example, you might use details to send a localized error message or retry
 // parameters to the client.
 //
-// The [google.golang.org/genproto/googleapis/rpc/errdetails] package contains a
-// variety of Protobuf messages commonly used as error details.
+// The [com.google.rpc](https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/rpc/package-summary.html)
+// package contains a variety of Protobuf messages commonly used as error details.
 data class ConnectErrorDetail(
     val type: String,
     val payload: ByteString,

--- a/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/com/connectrpc/impl/ProtocolClient.kt
@@ -109,11 +109,10 @@ class ProtocolClient(
                     )
                     return@httpClientUnary
                 }
-                val exception = finalResponse.cause?.setErrorParser(serializationStrategy.errorDetailParser())
-                if (exception != null) {
+                if (finalResponse.cause != null) {
                     onResult(
                         ResponseMessage.Failure(
-                            exception,
+                            finalResponse.cause,
                             finalResponse.headers,
                             finalResponse.trailers,
                         ),

--- a/library/src/main/kotlin/com/connectrpc/protocols/Envelope.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/Envelope.kt
@@ -67,11 +67,9 @@ class Envelope {
             }
             val headerByte = source.readByte().toInt()
             val length = source.readInt().toLong()
-            val message = if (source.size > length) {
+            val message = if (source.size >= length) {
                 // extract relevant subset for this message
                 Buffer().write(source as Source, length)
-            } else if (source.size == length) {
-                source
             } else {
                 throw ConnectException(
                     code = Code.INTERNAL_ERROR,

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCCompletion.kt
@@ -46,10 +46,11 @@ internal data class GRPCCompletion(
         } else {
             ConnectException(
                 code = code,
-                errorDetailParser = serializationStrategy.errorDetailParser(),
                 message = message,
-                details = errorDetails,
                 metadata = metadata,
+            ).withErrorDetails(
+                serializationStrategy.errorDetailParser(),
+                errorDetails,
             )
         }
     }

--- a/library/src/test/kotlin/com/connectrpc/ConnectExceptionTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/ConnectExceptionTest.kt
@@ -32,30 +32,14 @@ class ConnectExceptionTest {
         whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
         val connectException = ConnectException(
             code = Code.UNKNOWN,
+        ).withErrorDetails(
+            errorParser = errorDetailParser,
             details = listOf(
                 errorDetail,
-                errorDetail,
-            ),
-            errorDetailParser = errorDetailParser,
-        )
-        val parsedResult = connectException.unpackedDetails(String::class)
-        assertThat(parsedResult).contains("unpacked_value", "unpacked_value")
-    }
-
-    @Test
-    fun completionParsingUnset() {
-        val errorDetail = ConnectErrorDetail(
-            "type",
-            "value".encodeUtf8(),
-        )
-        whenever(errorDetailParser.unpack(errorDetail.pb, String::class)).thenReturn("unpacked_value")
-        val connectException = ConnectException(
-            code = Code.UNKNOWN,
-            details = listOf(
                 errorDetail,
             ),
         )
         val parsedResult = connectException.unpackedDetails(String::class)
-        assertThat(parsedResult).isEmpty()
+        assertThat(parsedResult).contains("unpacked_value", "unpacked_value")
     }
 }

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -174,12 +174,17 @@ class GRPCWebInterceptorTest {
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
-        val envelopedMessage = Envelope.pack(Buffer().write("message".encodeUtf8()), GzipCompressionPool, 0)
+        val responseBody = Envelope.pack(Buffer().write("message".encodeUtf8()), GzipCompressionPool, 0)
+        // And add end-stream message w/ trailers, too
+        val endStreamMessageContents = "grpc-status: 0\r\n".encodeUtf8()
+        responseBody.writeByte(GRPCWebInterceptor.TRAILERS_BIT)
+        responseBody.writeInt(endStreamMessageContents.size)
+        responseBody.write(endStreamMessageContents)
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = mapOf("grpc-encoding" to listOf("gzip")),
-                message = envelopedMessage,
+                headers = mapOf(GRPC_ENCODING to listOf("gzip")),
+                message = responseBody,
                 trailers = emptyMap(),
             ),
         )
@@ -196,12 +201,17 @@ class GRPCWebInterceptorTest {
         val grpcWebInterceptor = GRPCWebInterceptor(config)
         val unaryFunction = grpcWebInterceptor.unaryFunction()
 
-        val envelopedMessage = Envelope.pack(Buffer().write("message".encodeUtf8()), GzipCompressionPool, 1)
+        val responseBody = Envelope.pack(Buffer().write("message".encodeUtf8()), GzipCompressionPool, 1)
+        // And add end-stream message w/ trailers, too
+        val endStreamMessageContents = "grpc-status: 0\r\n".encodeUtf8()
+        responseBody.writeByte(GRPCWebInterceptor.TRAILERS_BIT)
+        responseBody.writeInt(endStreamMessageContents.size)
+        responseBody.write(endStreamMessageContents)
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
                 headers = mapOf(GRPC_ENCODING to listOf(GzipCompressionPool.name())),
-                message = envelopedMessage,
+                message = responseBody,
                 trailers = emptyMap(),
             ),
         )


### PR DESCRIPTION
There are a handful of changes in here that go along with this update of the conformance tests.

1. This updates the HTTP code -> RPC code mappings per latest updates to the spec [here](https://github.com/connectrpc/connectrpc.com/pull/130).

2. The newest release candidate of conformance tests really wants clients to report "exception metadata" as trailers, and for that to be a combined view of headers _and_ trailers for unary and client-stream errors.

   The reasoning is related to the fact that, in the gRPC and gRPC-Web protocols, a server can choose to combine headers and trailers into a "trailers-only" response when there are no response messages (which is always the case for unary and client-stream error responses). So the caller only checking headers or trailers when querying a particular key is brittle; and the caller checking _both_ headers and trailers is annoying and verbose. Instead, the combined metadata is reported as part of the exception, and the caller then has one bucket of metadata to query for a particular key, which is less error-prone.

3. Unary and client-stream operations now properly handle cases where there is either zero or more than one response message combined with an non-error status. They return "unimplemented" as indicated by [this doc](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) on RPC status codes (search therein for "cardinality violation").

4. In the Connect protocol, we correctly default to the code inferred from the HTTP status code, instead of always falling back to "unknown" in the event that the code cannot be successfully parsed from the JSON error body.

5. The `ConnectException` now uses a private constructor to provide a strong invariant that the error detail parser is always non-nil if there are non-empty error details. Previously, the old constructor allowed a caller to provide non-empty details but a null error parser, in which case the `unpackedDetails` method would not behave correctly. It also had an awkward public `setErrorParser` method which was actually only called from one place and was not even needed (and was technically not needed since it was previously declared as a `data` class, which means it gets an automatic `copy` method that could have been used to set the parser field).

   This is technically a backwards-incompatible change since the public constructor now has two fewer parameters. It is also no longer a `data` class (since the automatic `copy` method would have allowed the new invariant to be subverted -- a caller could invoke `ex.copy(errorDetailParser = null)`).