### PR TITLE
Some fixes noticed when testing against 'main' of conformance

### DIFF
--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -490,7 +490,12 @@ class ConnectInterceptorTest {
 
         assertThat(result).isInstanceOf(StreamResult.Headers::class.java)
         val headerResult = result as StreamResult.Headers
-        assertThat(headerResult.headers).isEqualTo(mapOf(CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip")))
+        assertThat(headerResult.headers).isEqualTo(
+            mapOf(
+                "trailer-x-some-key" to listOf("some_value"),
+                CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
We are hoping to cut a _final_ v1.0.0 of the conformance suite this week. It has a couple of minor changes from rc4. I wanted to make sure they wouldn't cause issues (particularly, [this pending PR](https://github.com/connectrpc/conformance/pull/840), which could possibly impact some of the logic I just added in #248 related to reporting trailers and merging headers+trailers in error metadata).

And... this ended up exposing some issues.

For one, I had not updated the Connect stream protocol in the same way as the gRPC-Web and gRPC protocols regarding merging of headers+trailers in metadata. I didn't notice in the previous PR because it was actually the "trailers only" responses that tickled test failures related to this (the connect-go reference server will only use "trailers only" responses for gRPC-Web, not for other protocols). For two, this code path was not correctly setting the trailers of the `StreamResult.Completed` object. Oops 🤦.

After I fixed that, I just happened to observe a conformance test flake that caused the client to hang. It turned out to be due to uncaught exception while trying to drain the response body in a unary RPC. So that's what warranted the other changes in here, adding `try/catch` to the unary flow of `ConnectOkHttpClient` and extracting the `safeTrailers` helper so it can also be used from that unary flow.

While making the above change, I greatly simplified the `safeTrailers` helper because it seemed to be incorrect: it was almost always computing empty trailers in these unary flows (which causes issues for gRPC calls, which rely on trailers to convey the status code). After re-reading the code, it's not clear why it was wrong, and I didn't have the patience to try to put it in a debugger to step through it and understand it. I just simplified it, removing the questionable conditional, and that fixed it.