### PR TITLE
Fix all conformance failures other than timeouts/deadlines

### DIFF
--- a/conformance/client/known-failing-stream-cases.txt
+++ b/conformance/client/known-failing-stream-cases.txt
@@ -6,6 +6,3 @@ Timeouts/HTTPVersion:2/**/bidi-stream/**
 
 # Deadline headers are not currently set.
 Deadline Propagation/**
-
-# Bug: incorrect code attribution for these failures (UNKNOWN instead of INTERNAL)
-Connect Unexpected Responses/**/unexpected-stream-codec

--- a/conformance/client/known-failing-unary-cases.txt
+++ b/conformance/client/known-failing-unary-cases.txt
@@ -1,13 +1,2 @@
 # Deadline headers are not currently set.
 Deadline Propagation/**
-
-# Bug: response content-type is not correctly checked
-**/unexpected-content-type
-
-# Bug: "trailers-only" responses are not correctly identified.
-# If headers contain "grpc-status", this client assumes it is a
-# trailers-only response. However, a trailers-only response should
-# instead be identified by lack of body or HTTP trailers.
-gRPC Unexpected Responses/**/trailers-only/*
-gRPC-Web Unexpected Responses/**/trailers-only/ignore-header-if-body-present
-

--- a/library/src/main/kotlin/com/connectrpc/AnyError.kt
+++ b/library/src/main/kotlin/com/connectrpc/AnyError.kt
@@ -17,7 +17,8 @@ package com.connectrpc
 import okio.ByteString
 
 /**
- * This is an Any adapter for various base data types.
+ * This is a protobuf-runtime-agnostic representation of google.protobuf.Any
+ * messages, which are used to represent error details in gRPC.
  */
 class AnyError(
     val typeUrl: String,

--- a/library/src/main/kotlin/com/connectrpc/Code.kt
+++ b/library/src/main/kotlin/com/connectrpc/Code.kt
@@ -36,7 +36,7 @@ enum class Code(val codeName: String, val value: Int) {
     ABORTED("aborted", 10),
     OUT_OF_RANGE("out_of_range", 11),
     UNIMPLEMENTED("unimplemented", 12),
-    INTERNAL_ERROR("internal", 13),
+    INTERNAL_ERROR("internal", 13), // TODO: rename enum value to INTERNAL
     UNAVAILABLE("unavailable", 14),
     DATA_LOSS("data_loss", 15),
     UNAUTHENTICATED("unauthenticated", 16),

--- a/library/src/main/kotlin/com/connectrpc/Codec.kt
+++ b/library/src/main/kotlin/com/connectrpc/Codec.kt
@@ -32,6 +32,7 @@ const val codecNameJSON = CODEC_NAME_JSON
  * Defines a type that is capable of encoding and decoding messages using a specific format.
  */
 interface Codec<E> {
+    // TODO: remove this method or unify somehow with SerializationStrategy.serializationName?
     /**
      * @return The name of the codec's format (e.g., "json", "proto"). Usually consumed
      * in the form of adding the `content-type` header via "application/{name}".

--- a/library/src/main/kotlin/com/connectrpc/ErrorDetailParser.kt
+++ b/library/src/main/kotlin/com/connectrpc/ErrorDetailParser.kt
@@ -24,12 +24,14 @@ import kotlin.reflect.KClass
  */
 interface ErrorDetailParser {
     /**
-     * Unpack the underlying payload into the input class type.
+     * Unpack the given Any payload into the input class type.
      */
     fun <E : Any> unpack(any: AnyError, clazz: KClass<E>): E?
 
     /**
-     * Parse payload for a list of error details.
+     * Parse the given bytes for a list of error details. The given
+     * bytes will be the serialized form of a google.rpc.Status
+     * Protobuf message.
      */
     fun parseDetails(bytes: ByteArray): List<ConnectErrorDetail>
 }

--- a/library/src/main/kotlin/com/connectrpc/SerializationStrategy.kt
+++ b/library/src/main/kotlin/com/connectrpc/SerializationStrategy.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 interface SerializationStrategy {
 
     /**
-     * The name of the serialization. Used in the content-encoding
+     * The name of the serialization. Used in the content-type
      * header.
      */
     fun serializationName(): String

--- a/library/src/main/kotlin/com/connectrpc/StreamResult.kt
+++ b/library/src/main/kotlin/com/connectrpc/StreamResult.kt
@@ -22,6 +22,9 @@ package com.connectrpc
 sealed class StreamResult<Output> {
     // Headers have been received over the stream.
     class Headers<Output>(val headers: com.connectrpc.Headers) : StreamResult<Output>() {
+        // TODO: This should include an HTTP status code, too. Computing an RPC code
+        //       from the HTTP status code should be part of the protocol impl, not
+        //       pushed down to the HTTPClientInterface impl.
         override fun toString(): String {
             return "Headers{headers=$headers}"
         }

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectConstants.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectConstants.kt
@@ -16,6 +16,7 @@ package com.connectrpc.protocols
 
 const val ACCEPT_ENCODING = "accept-encoding"
 const val CONTENT_ENCODING = "content-encoding"
+const val CONTENT_TYPE = "content-type"
 const val CONNECT_STREAMING_CONTENT_ENCODING = "connect-content-encoding"
 const val CONNECT_STREAMING_ACCEPT_ENCODING = "connect-accept-encoding"
 const val CONNECT_PROTOCOL_VERSION_KEY = "connect-protocol-version"

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
@@ -122,8 +122,8 @@ internal class ConnectInterceptor(
                 } else {
                     message = responseBody
                     val isValidContentType =
-                        (serializationStrategy.serializationName() == "json" && contentTypeIsJSON(contentType))
-                                || contentType == "application/" + serializationStrategy.serializationName()
+                        (serializationStrategy.serializationName() == "json" && contentTypeIsJSON(contentType)) ||
+                            contentType == "application/" + serializationStrategy.serializationName()
                     if (isValidContentType) {
                         exception = null
                     } else {
@@ -184,11 +184,13 @@ internal class ConnectInterceptor(
                             // this an internal error. Otherwise, we infer a code from the HTTP status,
                             // which means a code of UNKNOWN since HTTP status is 200.
                             val code = if (contentType.startsWith("application/connect+")) Code.INTERNAL_ERROR else Code.UNKNOWN
-                            StreamResult.Complete(ConnectException(
-                                code = code,
-                                message = "unexpected content-type: $contentType",
-                                metadata = responseHeaders,
-                            ))
+                            StreamResult.Complete(
+                                ConnectException(
+                                    code = code,
+                                    message = "unexpected content-type: $contentType",
+                                    metadata = responseHeaders,
+                                ),
+                            )
                         } else {
                             responseCompressionPool =
                                 clientConfig.compressionPool(responseHeaders[CONNECT_STREAMING_CONTENT_ENCODING]?.first())

--- a/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
@@ -38,5 +38,9 @@ internal class EndStreamResponseJSON(
 )
 
 internal fun contentTypeIsJSON(contentType: String): Boolean {
+    // TODO: This could be more robust, like actually parsing the content-type.
+    // There exists a good helper for that, but it's in okhttp, which we intentionally
+    // don't have as a dep for this module, which aims to be agnostic of the actual
+    // HTTP client implementation to use.
     return contentType == "application/json" || contentType == "application/json; charset=utf-8"
 }

--- a/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
@@ -36,3 +36,7 @@ internal class EndStreamResponseJSON(
     @Json(name = "error") val error: ErrorPayloadJSON?,
     @Json(name = "metadata") val metadata: Headers?,
 )
+
+internal fun contentTypeIsJSON(contentType: String): Boolean {
+    return contentType == "application/json" || contentType == "application/json; charset=utf-8"
+}

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -107,7 +107,7 @@ internal class GRPCInterceptor(
                             cause = ConnectException(
                                 code = Code.UNIMPLEMENTED,
                                 message = "unary stream has no messages",
-                                metadata = headers.plus(trailers)
+                                metadata = headers.plus(trailers),
                             ),
                         )
                     }
@@ -123,7 +123,7 @@ internal class GRPCInterceptor(
                             cause = ConnectException(
                                 code = Code.UNIMPLEMENTED,
                                 message = "unary stream has multiple messages",
-                                metadata = headers.plus(trailers)
+                                metadata = headers.plus(trailers),
                             ),
                         )
                     }
@@ -217,11 +217,11 @@ internal class GRPCInterceptor(
     }
 }
 
-internal fun contentTypeIsGRPC(contentType: String) : Boolean {
+internal fun contentTypeIsGRPC(contentType: String): Boolean {
     return contentType == "application/grpc" || contentType.startsWith("application/grpc+")
 }
 
-internal fun contentTypeIsExpectedGRPC(contentType: String, expectCodec: String) : Boolean {
-    return (expectCodec == "proto" && contentType == "application/grpc" )
-        || contentType == "application/grpc+$expectCodec"
+internal fun contentTypeIsExpectedGRPC(contentType: String, expectCodec: String): Boolean {
+    return (expectCodec == "proto" && contentType == "application/grpc") ||
+        contentType == "application/grpc+$expectCodec"
 }

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCInterceptor.kt
@@ -67,16 +67,32 @@ internal class GRPCInterceptor(
                 if (response.cause != null) {
                     return@UnaryFunction response.clone(message = Buffer())
                 }
+                val headers = response.headers
                 if (response.status != 200) {
                     return@UnaryFunction response.clone(
                         message = Buffer(),
                         cause = ConnectException(
                             code = Code.fromHTTPStatus(response.status),
                             message = "unexpected status code: ${response.status}",
+                            metadata = headers,
                         ),
                     )
                 }
-                val headers = response.headers
+                val contentType = headers[CONTENT_TYPE]?.first() ?: ""
+                if (!contentTypeIsExpectedGRPC(contentType, serializationStrategy.serializationName())) {
+                    // If content-type looks like it could be a gRPC server's response, consider
+                    // this an internal error. Otherwise, we infer a code from the HTTP status,
+                    // which means a code of UNKNOWN since HTTP status is 200.
+                    val code = if (contentTypeIsGRPC(contentType)) Code.INTERNAL_ERROR else Code.UNKNOWN
+                    return@UnaryFunction response.clone(
+                        message = Buffer(),
+                        cause = ConnectException(
+                            code = code,
+                            message = "unexpected content-type: $contentType",
+                            metadata = headers,
+                        ),
+                    )
+                }
                 var trailers = response.trailers
                 val hasBody = !response.message.buffer.exhausted()
                 val completion = completionParser.parse(headers, hasBody, trailers)
@@ -91,6 +107,7 @@ internal class GRPCInterceptor(
                             cause = ConnectException(
                                 code = Code.UNIMPLEMENTED,
                                 message = "unary stream has no messages",
+                                metadata = headers.plus(trailers)
                             ),
                         )
                     }
@@ -106,6 +123,7 @@ internal class GRPCInterceptor(
                             cause = ConnectException(
                                 code = Code.UNIMPLEMENTED,
                                 message = "unary stream has multiple messages",
+                                metadata = headers.plus(trailers)
                             ),
                         )
                     }
@@ -138,11 +156,25 @@ internal class GRPCInterceptor(
             streamResultFunction = { res ->
                 res.fold(
                     onHeaders = { result ->
-                        val headers = result.headers
-                        responseHeaders = headers
-                        responseCompressionPool = clientConfig
-                            .compressionPool(headers[GRPC_ENCODING]?.first())
-                        StreamResult.Headers(headers)
+                        responseHeaders = result.headers
+                        val contentType = responseHeaders[CONTENT_TYPE]?.first() ?: ""
+                        if (!contentTypeIsExpectedGRPC(contentType, serializationStrategy.serializationName())) {
+                            // If content-type looks like it could be a gRPC server's response, consider
+                            // this an internal error. Otherwise, we infer a code from the HTTP status,
+                            // which means a code of UNKNOWN since HTTP status is 200.
+                            val code = if (contentTypeIsGRPC(contentType)) Code.INTERNAL_ERROR else Code.UNKNOWN
+                            StreamResult.Complete(
+                                cause = ConnectException(
+                                    code = code,
+                                    message = "unexpected content-type: $contentType",
+                                    metadata = responseHeaders,
+                                ),
+                            )
+                        } else {
+                            responseCompressionPool = clientConfig
+                                .compressionPool(responseHeaders[GRPC_ENCODING]?.first())
+                            StreamResult.Headers(responseHeaders)
+                        }
                     },
                     onMessage = { result ->
                         streamEmpty = false
@@ -183,4 +215,13 @@ internal class GRPCInterceptor(
         }
         return headers
     }
+}
+
+internal fun contentTypeIsGRPC(contentType: String) : Boolean {
+    return contentType == "application/grpc" || contentType.startsWith("application/grpc+")
+}
+
+internal fun contentTypeIsExpectedGRPC(contentType: String, expectCodec: String) : Boolean {
+    return (expectCodec == "proto" && contentType == "application/grpc" )
+        || contentType == "application/grpc+$expectCodec"
 }

--- a/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/GRPCWebInterceptor.kt
@@ -295,11 +295,11 @@ internal class GRPCWebInterceptor(
     }
 }
 
-internal fun contentTypeIsGRPCWeb(contentType: String) : Boolean {
+internal fun contentTypeIsGRPCWeb(contentType: String): Boolean {
     return contentType == "application/grpc-web" || contentType.startsWith("application/grpc-web+")
 }
 
-internal fun contentTypeIsExpectedGRPCWeb(contentType: String, expectCodec: String) : Boolean {
-    return (expectCodec == "proto" && contentType == "application/grpc-web" )
-            || contentType == "application/grpc-web+$expectCodec"
+internal fun contentTypeIsExpectedGRPCWeb(contentType: String, expectCodec: String): Boolean {
+    return (expectCodec == "proto" && contentType == "application/grpc-web") ||
+        contentType == "application/grpc-web+$expectCodec"
 }

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -101,9 +101,11 @@ class InterceptorChainTest {
 
     @Test
     fun lifo_stream_result() {
-        val streamResult = streamingChain.streamResultFunction(StreamResult.Headers(
-            mapOf(CONTENT_TYPE to listOf("application/connect+encoding_type")),
-        )) as StreamResult.Headers
+        val streamResult = streamingChain.streamResultFunction(
+            StreamResult.Headers(
+                mapOf(CONTENT_TYPE to listOf("application/connect+encoding_type")),
+            ),
+        ) as StreamResult.Headers
         assertThat(streamResult.headers["id"]).containsExactly("4", "3", "2", "1")
     }
 

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -18,6 +18,7 @@ import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.UnaryHTTPRequest
 import com.connectrpc.http.clone
+import com.connectrpc.protocols.CONTENT_TYPE
 import com.connectrpc.protocols.Envelope
 import com.connectrpc.protocols.NetworkProtocol
 import okio.Buffer
@@ -25,6 +26,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.net.URL
 
 private val UNARY_METHOD_SPEC = MethodSpec(
@@ -69,6 +71,7 @@ class InterceptorChainTest {
         )
         unaryChain = protocolClientConfig.createInterceptorChain()
         streamingChain = protocolClientConfig.createStreamingInterceptorChain()
+        whenever(protocolClientConfig.serializationStrategy.serializationName()).thenReturn("encoding_type")
     }
 
     @Test
@@ -98,7 +101,9 @@ class InterceptorChainTest {
 
     @Test
     fun lifo_stream_result() {
-        val streamResult = streamingChain.streamResultFunction(StreamResult.Headers(emptyMap())) as StreamResult.Headers
+        val streamResult = streamingChain.streamResultFunction(StreamResult.Headers(
+            mapOf(CONTENT_TYPE to listOf("application/connect+encoding_type")),
+        )) as StreamResult.Headers
         assertThat(streamResult.headers["id"]).containsExactly("4", "3", "2", "1")
     }
 

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -292,7 +292,7 @@ class ConnectInterceptorTest {
             HTTPResponse(
                 // body contents override status code
                 status = 503,
-                headers = emptyMap(),
+                headers = mapOf(CONTENT_TYPE to listOf("application/json; charset=utf-8")),
                 message = Buffer().write(json.encodeUtf8()),
                 trailers = emptyMap(),
             ),
@@ -483,6 +483,7 @@ class ConnectInterceptorTest {
             StreamResult.Headers(
                 headers = mapOf(
                     "trailer-x-some-key" to listOf("some_value"),
+                    CONTENT_TYPE to listOf("application/connect+encoding_type"),
                     CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
                 ),
             ),
@@ -493,6 +494,7 @@ class ConnectInterceptorTest {
         assertThat(headerResult.headers).isEqualTo(
             mapOf(
                 "trailer-x-some-key" to listOf("some_value"),
+                CONTENT_TYPE to listOf("application/connect+encoding_type"),
                 CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
             ),
         )
@@ -536,6 +538,7 @@ class ConnectInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
+                    CONTENT_TYPE to listOf("application/connect+encoding_type"),
                     CONNECT_STREAMING_CONTENT_ENCODING to listOf("gzip"),
                 ),
             ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -185,7 +185,7 @@ class GRPCInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = emptyMap(),
+                headers = mapOf(CONTENT_TYPE to listOf("application/grpc+encoding_type")),
                 message = envelopedMessage,
                 trailers = mapOf(
                     GRPC_STATUS_TRAILER to listOf("0"),
@@ -209,7 +209,10 @@ class GRPCInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = mapOf(GRPC_ENCODING to listOf(GzipCompressionPool.name())),
+                headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc+encoding_type"),
+                    GRPC_ENCODING to listOf(GzipCompressionPool.name()),
+                ),
                 message = envelopedMessage,
                 trailers = mapOf(
                     GRPC_STATUS_TRAILER to listOf("0"),
@@ -253,7 +256,7 @@ class GRPCInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = emptyMap(),
+                headers = mapOf(CONTENT_TYPE to listOf("application/grpc+encoding_type")),
                 message = Buffer().write(json.encodeUtf8()),
                 trailers = mapOf(
                     GRPC_STATUS_TRAILER to listOf("${Code.RESOURCE_EXHAUSTED.value}"),
@@ -423,7 +426,8 @@ class GRPCInterceptorTest {
 
         val result = streamFunction.streamResultFunction(
             StreamResult.Headers(
-                mapOf(
+                headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc+encoding_type"),
                     "key" to listOf("value"),
                 ),
             ),
@@ -471,6 +475,7 @@ class GRPCInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc+encoding_type"),
                     GRPC_ENCODING to listOf(GzipCompressionPool.name()),
                 ),
             ),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -183,7 +183,10 @@ class GRPCWebInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = mapOf(GRPC_ENCODING to listOf("gzip")),
+                headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc-web+encoding_type"),
+                    GRPC_ENCODING to listOf("gzip"),
+                ),
                 message = responseBody,
                 trailers = emptyMap(),
             ),
@@ -210,7 +213,10 @@ class GRPCWebInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = mapOf(GRPC_ENCODING to listOf(GzipCompressionPool.name())),
+                headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc-web+encoding_type"),
+                    GRPC_ENCODING to listOf(GzipCompressionPool.name()),
+                ),
                 message = responseBody,
                 trailers = emptyMap(),
             ),
@@ -232,6 +238,7 @@ class GRPCWebInterceptorTest {
             HTTPResponse(
                 status = 200,
                 headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc-web+encoding_type"),
                     GRPC_STATUS_TRAILER to listOf("${Code.RESOURCE_EXHAUSTED.value}"),
                 ),
                 message = Buffer(),
@@ -259,7 +266,7 @@ class GRPCWebInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = emptyMap(),
+                headers = mapOf(CONTENT_TYPE to listOf("application/grpc-web+encoding_type")),
                 message = trailers,
                 trailers = emptyMap(),
             ),
@@ -290,7 +297,7 @@ class GRPCWebInterceptorTest {
         val response = unaryFunction.responseFunction(
             HTTPResponse(
                 status = 200,
-                headers = emptyMap(),
+                headers = mapOf(CONTENT_TYPE to listOf("application/grpc-web+encoding_type")),
                 message = responseBody,
                 trailers = emptyMap(),
             ),
@@ -452,6 +459,7 @@ class GRPCWebInterceptorTest {
                 headers = mapOf(
                     // Doesn't get passed as headers.
                     "trailer-x-some-key" to listOf("some_value"),
+                    CONTENT_TYPE to listOf("application/grpc-web+encoding_type"),
                     GRPC_ENCODING to listOf("gzip"),
                 ),
             ),
@@ -498,6 +506,7 @@ class GRPCWebInterceptorTest {
         streamFunction.streamResultFunction(
             StreamResult.Headers(
                 headers = mapOf(
+                    CONTENT_TYPE to listOf("application/grpc-web+encoding_type"),
                     GRPC_ENCODING to listOf("gzip"),
                 ),
             ),

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -112,6 +112,7 @@ private class ResponseCallback(
                     cause = ConnectException(
                         code = Code.fromHTTPStatus(httpStatus),
                         message = "unexpected HTTP status: $httpStatus ${response.originalMessage()}",
+                        metadata = headers,
                     ),
                 )
                 onResult(finalResult)


### PR DESCRIPTION
The first two commits include fixes to the protocol logic to fix the known failures in conformance tests.

This still leaves the timeout/deadline propagation cases failing since those will require something more significant to resolve.

* The first commit fixes how trailers-only responses are classified. This was previously just looking for a "grpc-status" key in the headers. If it was present, it was treating it as a trailers-only response, even if there was a body and/or trailers.
* The second commit fixes the client to report errors in the face of unexpected response content types. I wish this were less verbose: I think in the future we can likely find some low-hanging fruit ways to improve the code organization and increase code sharing in these protocol implementations (especially gRPC and gRPC-Web).

The third commit is just some minor updates to comments and TODOs that I figured I'd tweak while I was in these files. Hopefully they all make sense.

The final commit cleans up the known failing test case configuration -- to remove everything but the timeout/deadline tests.