### PR TITLE
Introduce CallOptions, to support future per-call options (like timeouts)

### DIFF
--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaBidiStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaBidiStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.BidiStreamClient
 import com.connectrpc.conformance.v1.BidiStreamRequest
 import com.connectrpc.conformance.v1.BidiStreamResponse
@@ -26,7 +26,7 @@ class JavaBidiStreamClient(
     BidiStreamRequest.getDefaultInstance(),
     BidiStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(headers: Headers): BidiStream<BidiStreamRequest, BidiStreamResponse> {
-        return BidiStream.new(client.bidiStream(headers))
+    override suspend fun execute(options: CallOptions): BidiStream<BidiStreamRequest, BidiStreamResponse> {
+        return BidiStream.new(client.bidiStream(options))
     }
 }

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaClientStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaClientStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.ClientStreamClient
 import com.connectrpc.conformance.v1.ClientStreamRequest
 import com.connectrpc.conformance.v1.ClientStreamResponse
@@ -26,7 +26,7 @@ class JavaClientStreamClient(
     ClientStreamRequest.getDefaultInstance(),
     ClientStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(headers: Headers): ClientStream<ClientStreamRequest, ClientStreamResponse> {
-        return ClientStream.new(client.clientStream(headers))
+    override suspend fun execute(options: CallOptions): ClientStream<ClientStreamRequest, ClientStreamResponse> {
+        return ClientStream.new(client.clientStream(options))
     }
 }

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaIdempotentUnaryClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaIdempotentUnaryClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,19 +29,19 @@ class JavaIdempotentUnaryClient(
     IdempotentUnaryRequest.getDefaultInstance(),
     IdempotentUnaryResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: IdempotentUnaryRequest, headers: Headers): ResponseMessage<IdempotentUnaryResponse> {
-        return client.idempotentUnary(req, headers)
+    override suspend fun execute(req: IdempotentUnaryRequest, options: CallOptions): ResponseMessage<IdempotentUnaryResponse> {
+        return client.idempotentUnary(req, options)
     }
 
     override fun execute(
         req: IdempotentUnaryRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<IdempotentUnaryResponse>) -> Unit,
     ): Cancelable {
-        return client.idempotentUnary(req, headers, onFinish)
+        return client.idempotentUnary(req, options, onFinish)
     }
 
-    override fun blocking(req: IdempotentUnaryRequest, headers: Headers): UnaryBlockingCall<IdempotentUnaryResponse> {
-        return client.idempotentUnaryBlocking(req, headers)
+    override fun blocking(req: IdempotentUnaryRequest, options: CallOptions): UnaryBlockingCall<IdempotentUnaryResponse> {
+        return client.idempotentUnaryBlocking(req, options)
     }
 }

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.ResponseStream
 import com.connectrpc.conformance.client.adapt.ServerStreamClient
 import com.connectrpc.conformance.v1.ConformanceServiceClient
@@ -27,8 +27,8 @@ class JavaServerStreamClient(
     ServerStreamRequest.getDefaultInstance(),
     ServerStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: ServerStreamRequest, headers: Headers): ResponseStream<ServerStreamResponse> {
-        val stream = client.serverStream(headers)
+    override suspend fun execute(req: ServerStreamRequest, options: CallOptions): ResponseStream<ServerStreamResponse> {
+        val stream = client.serverStream(options)
         val sendResult: Result<Unit>
         try {
             sendResult = stream.sendAndClose(req)

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnaryClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnaryClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,19 +29,19 @@ class JavaUnaryClient(
     UnaryRequest.getDefaultInstance(),
     UnaryResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: UnaryRequest, headers: Headers): ResponseMessage<UnaryResponse> {
-        return client.unary(req, headers)
+    override suspend fun execute(req: UnaryRequest, options: CallOptions): ResponseMessage<UnaryResponse> {
+        return client.unary(req, options)
     }
 
     override fun execute(
         req: UnaryRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<UnaryResponse>) -> Unit,
     ): Cancelable {
-        return client.unary(req, headers, onFinish)
+        return client.unary(req, options, onFinish)
     }
 
-    override fun blocking(req: UnaryRequest, headers: Headers): UnaryBlockingCall<UnaryResponse> {
-        return client.unaryBlocking(req, headers)
+    override fun blocking(req: UnaryRequest, options: CallOptions): UnaryBlockingCall<UnaryResponse> {
+        return client.unaryBlocking(req, options)
     }
 }

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnimplementedClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaUnimplementedClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.java
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,19 +29,19 @@ class JavaUnimplementedClient(
     UnimplementedRequest.getDefaultInstance(),
     UnimplementedResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: UnimplementedRequest, headers: Headers): ResponseMessage<UnimplementedResponse> {
-        return client.unimplemented(req, headers)
+    override suspend fun execute(req: UnimplementedRequest, options: CallOptions): ResponseMessage<UnimplementedResponse> {
+        return client.unimplemented(req, options)
     }
 
     override fun execute(
         req: UnimplementedRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<UnimplementedResponse>) -> Unit,
     ): Cancelable {
-        return client.unimplemented(req, headers, onFinish)
+        return client.unimplemented(req, options, onFinish)
     }
 
-    override fun blocking(req: UnimplementedRequest, headers: Headers): UnaryBlockingCall<UnimplementedResponse> {
-        return client.unimplementedBlocking(req, headers)
+    override fun blocking(req: UnimplementedRequest, options: CallOptions): UnaryBlockingCall<UnimplementedResponse> {
+        return client.unimplementedBlocking(req, options)
     }
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteBidiStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteBidiStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.BidiStreamClient
 import com.connectrpc.conformance.v1.BidiStreamRequest
 import com.connectrpc.conformance.v1.BidiStreamResponse
@@ -26,7 +26,7 @@ class JavaLiteBidiStreamClient(
     BidiStreamRequest.getDefaultInstance(),
     BidiStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(headers: Headers): BidiStream<BidiStreamRequest, BidiStreamResponse> {
-        return BidiStream.new(client.bidiStream(headers))
+    override suspend fun execute(options: CallOptions): BidiStream<BidiStreamRequest, BidiStreamResponse> {
+        return BidiStream.new(client.bidiStream(options))
     }
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteClientStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteClientStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.ClientStreamClient
 import com.connectrpc.conformance.v1.ClientStreamRequest
 import com.connectrpc.conformance.v1.ClientStreamResponse
@@ -26,7 +26,7 @@ class JavaLiteClientStreamClient(
     ClientStreamRequest.getDefaultInstance(),
     ClientStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(headers: Headers): ClientStream<ClientStreamRequest, ClientStreamResponse> {
-        return ClientStream.new(client.clientStream(headers))
+    override suspend fun execute(options: CallOptions): ClientStream<ClientStreamRequest, ClientStreamResponse> {
+        return ClientStream.new(client.clientStream(options))
     }
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteIdempotentUnaryClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteIdempotentUnaryClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,22 +29,19 @@ class JavaLiteIdempotentUnaryClient(
     IdempotentUnaryRequest.getDefaultInstance(),
     IdempotentUnaryResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(
-        req: IdempotentUnaryRequest,
-        headers: Headers,
-    ): ResponseMessage<IdempotentUnaryResponse> {
-        return client.idempotentUnary(req, headers)
+    override suspend fun execute(req: IdempotentUnaryRequest, options: CallOptions): ResponseMessage<IdempotentUnaryResponse> {
+        return client.idempotentUnary(req, options)
     }
 
     override fun execute(
         req: IdempotentUnaryRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<IdempotentUnaryResponse>) -> Unit,
     ): Cancelable {
-        return client.idempotentUnary(req, headers, onFinish)
+        return client.idempotentUnary(req, options, onFinish)
     }
 
-    override fun blocking(req: IdempotentUnaryRequest, headers: Headers): UnaryBlockingCall<IdempotentUnaryResponse> {
-        return client.idempotentUnaryBlocking(req, headers)
+    override fun blocking(req: IdempotentUnaryRequest, options: CallOptions): UnaryBlockingCall<IdempotentUnaryResponse> {
+        return client.idempotentUnaryBlocking(req, options)
     }
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteServerStreamClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteServerStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.conformance.client.adapt.ResponseStream
 import com.connectrpc.conformance.client.adapt.ServerStreamClient
 import com.connectrpc.conformance.v1.ConformanceServiceClient
@@ -27,8 +27,8 @@ class JavaLiteServerStreamClient(
     ServerStreamRequest.getDefaultInstance(),
     ServerStreamResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: ServerStreamRequest, headers: Headers): ResponseStream<ServerStreamResponse> {
-        val stream = client.serverStream(headers)
+    override suspend fun execute(req: ServerStreamRequest, options: CallOptions): ResponseStream<ServerStreamResponse> {
+        val stream = client.serverStream(options)
         val sendResult: Result<Unit>
         try {
             sendResult = stream.sendAndClose(req)

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnaryClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnaryClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,22 +29,19 @@ class JavaLiteUnaryClient(
     UnaryRequest.getDefaultInstance(),
     UnaryResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(
-        req: UnaryRequest,
-        headers: Headers,
-    ): ResponseMessage<UnaryResponse> {
-        return client.unary(req, headers)
+    override suspend fun execute(req: UnaryRequest, options: CallOptions): ResponseMessage<UnaryResponse> {
+        return client.unary(req, options)
     }
 
     override fun execute(
         req: UnaryRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<UnaryResponse>) -> Unit,
     ): Cancelable {
-        return client.unary(req, headers, onFinish)
+        return client.unary(req, options, onFinish)
     }
 
-    override fun blocking(req: UnaryRequest, headers: Headers): UnaryBlockingCall<UnaryResponse> {
-        return client.unaryBlocking(req, headers)
+    override fun blocking(req: UnaryRequest, options: CallOptions): UnaryBlockingCall<UnaryResponse> {
+        return client.unaryBlocking(req, options)
     }
 }

--- a/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnimplementedClient.kt
+++ b/conformance/client/google-javalite/src/main/kotlin/com/connectrpc/conformance/client/javalite/JavaLiteUnimplementedClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.javalite
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.connectrpc.ResponseMessage
 import com.connectrpc.UnaryBlockingCall
 import com.connectrpc.conformance.client.adapt.UnaryClient
@@ -29,19 +29,19 @@ class JavaLiteUnimplementedClient(
     UnimplementedRequest.getDefaultInstance(),
     UnimplementedResponse.getDefaultInstance(),
 ) {
-    override suspend fun execute(req: UnimplementedRequest, headers: Headers): ResponseMessage<UnimplementedResponse> {
-        return client.unimplemented(req, headers)
+    override suspend fun execute(req: UnimplementedRequest, options: CallOptions): ResponseMessage<UnimplementedResponse> {
+        return client.unimplemented(req, options)
     }
 
     override fun execute(
         req: UnimplementedRequest,
-        headers: Headers,
+        options: CallOptions,
         onFinish: (ResponseMessage<UnimplementedResponse>) -> Unit,
     ): Cancelable {
-        return client.unimplemented(req, headers, onFinish)
+        return client.unimplemented(req, options, onFinish)
     }
 
-    override fun blocking(req: UnimplementedRequest, headers: Headers): UnaryBlockingCall<UnimplementedResponse> {
-        return client.unimplementedBlocking(req, headers)
+    override fun blocking(req: UnimplementedRequest, options: CallOptions): UnaryBlockingCall<UnimplementedResponse> {
+        return client.unimplementedBlocking(req, options)
     }
 }

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/Client.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc.conformance.client
 
+import com.connectrpc.CallOptions
 import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.ProtocolClientConfig
@@ -132,7 +133,7 @@ class Client(
         val canceler = client.execute(
             args.invokeStyle,
             msg,
-            req.requestHeaders,
+            CallOptions.headers(req.requestHeaders),
             resp::complete,
         )
         when (val cancel = req.cancel) {
@@ -161,7 +162,7 @@ class Client(
         ) {
             throw RuntimeException("client stream calls can only support `BeforeCloseSend` and 'AfterCloseSendMs' cancellation field, instead got ${req.cancel!!::class.simpleName}")
         }
-        return client.execute(req.requestHeaders) { stream ->
+        return client.execute(CallOptions.headers(req.requestHeaders)) { stream ->
             var numUnsent = 0
             for (i in req.requestMessages.indices) {
                 if (req.requestDelayMs > 0) {
@@ -217,7 +218,7 @@ class Client(
         val msg = fromAny(req.requestMessages[0], client.reqTemplate, SERVER_STREAM_REQUEST_NAME)
         var sent = false
         try {
-            return client.execute(msg, req.requestHeaders) { stream ->
+            return client.execute(msg, CallOptions.headers(req.requestHeaders)) { stream ->
                 sent = true
                 val cancel = req.cancel
                 if (cancel is Cancel.AfterCloseSendMs) {
@@ -255,7 +256,7 @@ class Client(
         client: BidiStreamClient<Req, Resp>,
         req: ClientCompatRequest,
     ): ClientResponseResult {
-        return client.execute(req.requestHeaders) { stream ->
+        return client.execute(CallOptions.headers(req.requestHeaders)) { stream ->
             var numUnsent = 0
             for (i in req.requestMessages.indices) {
                 if (req.requestDelayMs > 0) {
@@ -296,7 +297,7 @@ class Client(
         client: BidiStreamClient<Req, Resp>,
         req: ClientCompatRequest,
     ): ClientResponseResult {
-        return client.execute(req.requestHeaders) { stream ->
+        return client.execute(CallOptions.headers(req.requestHeaders)) { stream ->
             val cancel = req.cancel
             val payloads: MutableList<MessageLite> = mutableListOf()
             for (i in req.requestMessages.indices) {

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/BidiStreamClient.kt
@@ -15,7 +15,7 @@
 package com.connectrpc.conformance.client.adapt
 
 import com.connectrpc.BidirectionalStreamInterface
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.google.protobuf.MessageLite
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -44,16 +44,16 @@ abstract class BidiStreamClient<Req : MessageLite, Resp : MessageLite>(
      * stream is automatically closed when the block returns or throws.
      */
     suspend fun <R> execute(
-        headers: Headers,
+        options: CallOptions = CallOptions.empty,
         block: suspend CoroutineScope.(BidiStream<Req, Resp>) -> R,
     ): R {
-        val stream = execute(headers)
+        val stream = execute(options)
         return stream.use {
             coroutineScope { block(this, it) }
         }
     }
 
-    protected abstract suspend fun execute(headers: Headers): BidiStream<Req, Resp>
+    protected abstract suspend fun execute(options: CallOptions): BidiStream<Req, Resp>
 
     /**
      * A BidiStream combines a request stream and a response stream.

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ClientStreamClient.kt
@@ -14,8 +14,8 @@
 
 package com.connectrpc.conformance.client.adapt
 
+import com.connectrpc.CallOptions
 import com.connectrpc.ClientOnlyStreamInterface
-import com.connectrpc.Headers
 import com.connectrpc.ResponseMessage
 import com.connectrpc.asConnectException
 import com.google.protobuf.MessageLite
@@ -42,16 +42,16 @@ abstract class ClientStreamClient<Req : MessageLite, Resp : MessageLite>(
      * stream is automatically closed when the block returns or throws.
      */
     suspend fun <R> execute(
-        headers: Headers,
+        options: CallOptions = CallOptions.empty,
         block: suspend CoroutineScope.(ClientStream<Req, Resp>) -> R,
     ): R {
-        val stream = execute(headers)
+        val stream = execute(options)
         return stream.use {
             coroutineScope { block(this, it) }
         }
     }
 
-    protected abstract suspend fun execute(headers: Headers): ClientStream<Req, Resp>
+    protected abstract suspend fun execute(options: CallOptions): ClientStream<Req, Resp>
 
     /**
      * A ClientStream is just like a RequestStream, except that closing

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/adapt/ServerStreamClient.kt
@@ -14,7 +14,7 @@
 
 package com.connectrpc.conformance.client.adapt
 
-import com.connectrpc.Headers
+import com.connectrpc.CallOptions
 import com.google.protobuf.MessageLite
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
@@ -38,14 +38,14 @@ abstract class ServerStreamClient<Req : MessageLite, Resp : MessageLite>(
      */
     suspend fun <R> execute(
         req: Req,
-        headers: Headers,
+        options: CallOptions = CallOptions.empty,
         block: suspend CoroutineScope.(ResponseStream<Resp>) -> R,
     ): R {
-        val stream = execute(req, headers)
+        val stream = execute(req, options)
         return stream.use {
             coroutineScope { block(this, it) }
         }
     }
 
-    protected abstract suspend fun execute(req: Req, headers: Headers): ResponseStream<Resp>
+    protected abstract suspend fun execute(req: Req, options: CallOptions): ResponseStream<Resp>
 }

--- a/library/src/main/kotlin/com/connectrpc/CallOptions.kt
+++ b/library/src/main/kotlin/com/connectrpc/CallOptions.kt
@@ -1,0 +1,59 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc
+
+/**
+ * Represents options to use when invoking an RPC.
+ */
+sealed class CallOptions {
+    /**
+     * Request headers to send to the server.
+     */
+    abstract val headers: Headers
+
+    // TODO: add call option for timeout
+
+    companion object {
+        /** Empty value that indicate the use of default options. */
+        val empty = Builder().build()
+
+        /** Shorthand for creating options with a single value for the request headers. */
+        fun headers(headers: Headers): CallOptions {
+            return Builder().headers(headers).build()
+        }
+    }
+
+    /**
+     * Builds a set of call options.
+     */
+    class Builder {
+        private var headers: Headers = emptyMap()
+
+        /** Sets the request headers to send. */
+        fun headers(headers: Headers): Builder {
+            this.headers = headers
+            return this
+        }
+
+        /** Builds the options using the values accumulated so far. */
+        fun build(): CallOptions {
+            return CallOptionsImpl(headers)
+        }
+    }
+
+    private data class CallOptionsImpl(
+        override val headers: Headers,
+    ) : CallOptions()
+}

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientInterface.kt
@@ -28,85 +28,179 @@ interface ProtocolClientInterface {
      * Perform a unary (non-streaming) request.
      *
      * @param request The outbound request message.
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      * @param onResult Closure called when a response or error is received.
      *
      * @return A `Cancelable` which provides the ability to cancel the outbound request.
      */
     fun <Input : Any, Output : Any> unary(
         request: Input,
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
         onResult: (ResponseMessage<Output>) -> Unit,
     ): Cancelable
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "unary(request, CallOptions.headers(headers), methodSpec, onResult)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    fun <Input : Any, Output : Any> unary(
+        request: Input,
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+        onResult: (ResponseMessage<Output>) -> Unit,
+    ): Cancelable {
+        return unary(request, CallOptions.headers(headers), methodSpec, onResult)
+    }
 
     /**
      * Perform a suspended unary (non-streaming) request.
      *
      * @param request The outbound request message.
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      *
      * @return The ResponseMessage for the unary call.
      */
     suspend fun <Input : Any, Output : Any> unary(
         request: Input,
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
     ): ResponseMessage<Output>
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "unary(request, CallOptions.headers(headers), methodSpec)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    suspend fun <Input : Any, Output : Any> unary(
+        request: Input,
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+    ): ResponseMessage<Output> {
+        return unary(request, CallOptions.headers(headers), methodSpec)
+    }
 
     /**
      * Perform a synchronous unary (non-streaming) request.
      *
      * @param request The outbound request message.
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      *
      * @return The [UnaryBlockingCall] for the unary request.
      */
     fun <Input : Any, Output : Any> unaryBlocking(
         request: Input,
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
     ): UnaryBlockingCall<Output>
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "unaryBlocking(request, CallOptions.headers(headers), methodSpec)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    fun <Input : Any, Output : Any> unaryBlocking(
+        request: Input,
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+    ): UnaryBlockingCall<Output> {
+        return unaryBlocking(request, CallOptions.headers(headers), methodSpec)
+    }
 
     /**
      * Start a new bidirectional stream.
      *
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      *
      * @return An interface for interacting with and sending data over the bidirectional stream.
      */
     suspend fun <Input : Any, Output : Any> stream(
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
     ): BidirectionalStreamInterface<Input, Output>
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "stream(CallOptions.headers(headers), methodSpec)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    suspend fun <Input : Any, Output : Any> stream(
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+    ): BidirectionalStreamInterface<Input, Output> {
+        return stream(CallOptions.headers(headers), methodSpec)
+    }
 
     /**
      * Start a new server only stream.
      *
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      *
      * @return An interface for interacting with and receiving data over the server only stream.
      */
     suspend fun <Input : Any, Output : Any> serverStream(
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
     ): ServerOnlyStreamInterface<Input, Output>
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "serverStream(CallOptions.headers(headers), methodSpec)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    suspend fun <Input : Any, Output : Any> serverStream(
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+    ): ServerOnlyStreamInterface<Input, Output> {
+        return serverStream(CallOptions.headers(headers), methodSpec)
+    }
 
     /**
      * Start a new client only stream.
      *
-     * @param headers The outbound request headers to include.
-     * @param methodSpec The Method for RPC path.
+     * @param options Options used to invoke the RPC, such as outbound request headers,
+     *              timeout, etc.
+     * @param methodSpec The definition of the method to invoke
      *
      * @return An interface for interacting with and sending data over the client only stream.
      */
     suspend fun <Input : Any, Output : Any> clientStream(
-        headers: Headers,
+        options: CallOptions,
         methodSpec: MethodSpec<Input, Output>,
     ): ClientOnlyStreamInterface<Input, Output>
+
+    @Deprecated(
+        message = "Use signature that takes CallOptions instead",
+        replaceWith = ReplaceWith(
+            expression = "clientStream(CallOptions.headers(headers), methodSpec)",
+            imports = ["com.connectrpc.CallOptions"],
+        ),
+    )
+    suspend fun <Input : Any, Output : Any> clientStream(
+        headers: Headers,
+        methodSpec: MethodSpec<Input, Output>,
+    ): ClientOnlyStreamInterface<Input, Output> {
+        return clientStream(CallOptions.headers(headers), methodSpec)
+    }
 }

--- a/library/src/test/kotlin/com/connectrpc/impl/BidirectionalStreamTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/BidirectionalStreamTest.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc.impl
 
+import com.connectrpc.CallOptions
 import com.connectrpc.Codec
 import com.connectrpc.MethodSpec
 import com.connectrpc.ProtocolClientConfig
@@ -50,7 +51,7 @@ class BidirectionalStreamTest {
 
         CoroutineScope(Dispatchers.IO).launch {
             val stream = client.stream(
-                emptyMap(),
+                CallOptions.empty,
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,
@@ -80,7 +81,7 @@ class BidirectionalStreamTest {
 
         CoroutineScope(Dispatchers.IO).launch {
             val stream = client.stream(
-                emptyMap(),
+                CallOptions.empty,
                 MethodSpec(
                     path = "com.connectrpc.SomeService/Service",
                     String::class,

--- a/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/ProtocolClientTest.kt
@@ -14,6 +14,7 @@
 
 package com.connectrpc.impl
 
+import com.connectrpc.CallOptions
 import com.connectrpc.Codec
 import com.connectrpc.MethodSpec
 import com.connectrpc.ProtocolClientConfig
@@ -48,7 +49,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com/")
         client.unary(
             "input",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) { _ -> }
         val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -65,7 +66,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com")
         client.unary(
             "input",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) { _ -> }
         val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -82,7 +83,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com/")
         CoroutineScope(Dispatchers.IO).launch {
             client.stream(
-                emptyMap(),
+                CallOptions.empty,
                 createMethodSpec(StreamType.BIDI),
             )
             val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -100,7 +101,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com")
         CoroutineScope(Dispatchers.IO).launch {
             client.stream(
-                emptyMap(),
+                CallOptions.empty,
                 createMethodSpec(StreamType.BIDI),
             )
             val captor = argumentCaptor<HTTPRequest>()
@@ -117,7 +118,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com")
         client.unary(
             "",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) {}
         val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -133,7 +134,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com/")
         client.unary(
             "",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) {}
         val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -149,7 +150,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com/api")
         client.unary(
             "",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) {}
         val captor = argumentCaptor<UnaryHTTPRequest>()
@@ -165,7 +166,7 @@ class ProtocolClientTest {
         val client = createClient("https://connectrpc.com/api/")
         client.unary(
             "",
-            emptyMap(),
+            CallOptions.empty,
             createMethodSpec(StreamType.UNARY),
         ) {}
         val captor = argumentCaptor<UnaryHTTPRequest>()

--- a/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
+++ b/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
@@ -26,6 +26,7 @@ import buf.javamultiplefiles.unspecified.v1.UnspecifiedEmptyOuterClass
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedEmptyServiceClient
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedInnerMessageServiceClient
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedServiceClient
+import com.connectrpc.CallOptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -46,7 +47,7 @@ class PluginGenerationTest {
         val client = ElizaServiceClient(mock { })
         val request = NoPackage.SayRequest.newBuilder().setSentence("hello").build()
         CoroutineScope(Dispatchers.IO).launch {
-            client.say(request, emptyMap())
+            client.say(request, CallOptions.empty)
         }
         assertThat(request.sentence).isEqualTo("hello")
     }


### PR DESCRIPTION
This doesn't add anything new (like per-call timeouts) yet, but it sets up the APIs to allow adding it in the future.

The main change is to replace the use of `Headers` as an argument for every RPC invocation to instead be a new `CallOptions` type, and request headers are one of the options. (In this PR, they are actually the _only_ option. But we'd add per-call timeouts in the future, and possibly even per-call options relating to compression.)

This is done in a backwards-compatible way so that updating to this version of the library does not require re-generating code or changing application code. So it keeps the old method signatures, but deprecates them. In the generated code, the deprecated functions all have default implementations in the interface to call the new form, so that the generated implementation classes only need to override the new signature.

You can get an idea for what the generated interfaces look like by looking at the changes in `ProtocolClientInterface`.

You can review this commit-by-commit. I ran full tests (including the whole conformance suite) after each commit, as a way to verify backwards-compatibility of gen code and application code. The first commit updates the library; the second commit updates the gen-code; the third commit updates application code.