### PR TITLE
Add timeout enforcement to ProtocolClient

### DIFF
--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaServerStreamClient.kt
@@ -20,6 +20,8 @@ import com.connectrpc.conformance.client.adapt.ServerStreamClient
 import com.connectrpc.conformance.v1.ConformanceServiceClient
 import com.connectrpc.conformance.v1.ServerStreamRequest
 import com.connectrpc.conformance.v1.ServerStreamResponse
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 
 class JavaServerStreamClient(
     private val client: ConformanceServiceClient,
@@ -33,6 +35,21 @@ class JavaServerStreamClient(
         try {
             sendResult = stream.sendAndClose(req)
             if (sendResult.isFailure) {
+                // It can't be because stream.sendClose was already closed. So the operation
+                // must have already failed. Extract the reason via a call to receive. But
+                // if something is awry, don't block forever on the receive call.
+                try {
+                    withTimeout(50) {
+                        // Waits up to 50 milliseconds.
+                        stream.responseChannel().receive()
+                    }
+                } catch (_: TimeoutCancellationException) {
+                    // Receive did not complete :(
+                } catch (ex: Throwable) {
+                    throw ex
+                }
+                // Either receive did not complete or it did not fail (which
+                // shouldn't actually be possible).
                 throw sendResult.exceptionOrNull()!!
             }
         } catch (ex: Throwable) {

--- a/conformance/client/known-failing-stream-cases.txt
+++ b/conformance/client/known-failing-stream-cases.txt
@@ -1,8 +1,1 @@
-# We currently rely on OkHttp's "call timeout" to handle
-# RPC deadlines, but that is not enforced when the request
-# body is duplex. So timeouts don't currently work with
-# bidi streams.
-Timeouts/HTTPVersion:2/**/bidi-stream/**
-
-# Deadline headers are not currently set.
-Deadline Propagation/**
+# Currently there are zero failing tests.

--- a/conformance/client/known-failing-unary-cases.txt
+++ b/conformance/client/known-failing-unary-cases.txt
@@ -1,2 +1,1 @@
-# Deadline headers are not currently set.
-Deadline Propagation/**
+# Currently there are zero failing tests.

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -25,6 +25,8 @@ import com.connectrpc.protocols.NetworkProtocol
 import java.net.URI
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 typealias TimeoutOracle = (MethodSpec<*, *>) -> Duration?
 
@@ -81,7 +83,10 @@ class ProtocolClientConfig @JvmOverloads constructor(
     // is returned, the entire call must complete before it elapses. If the
     // call is still active at the end of the timeout period, it is cancelled
     // and will result in an exception with a Code.DEADLINE_EXCEEDED code.
-    val timeoutOracle: TimeoutOracle = { null },
+    //
+    // The default oracle, if not configured, returns a 10 second timeout for
+    // all operations.
+    val timeoutOracle: TimeoutOracle = { 10.toDuration(DurationUnit.SECONDS) },
     // Schedules timeout actions.
     val timeoutScheduler: Timeout.Scheduler = Timeout.DEFAULT_SCHEDULER,
 ) {

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -16,6 +16,7 @@ package com.connectrpc
 
 import com.connectrpc.compression.CompressionPool
 import com.connectrpc.compression.GzipCompressionPool
+import com.connectrpc.http.Timeout
 import com.connectrpc.protocols.ConnectInterceptor
 import com.connectrpc.protocols.GETConfiguration
 import com.connectrpc.protocols.GRPCInterceptor
@@ -23,11 +24,32 @@ import com.connectrpc.protocols.GRPCWebInterceptor
 import com.connectrpc.protocols.NetworkProtocol
 import java.net.URI
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+
+typealias TimeoutOracle = (MethodSpec<*, *>) -> Duration?
+
+/**
+ * Returns an oracle that provides the given timeouts for unary or stream
+ * operations, respectively.
+ */
+fun simpleTimeouts(unaryTimeout: Duration?, streamTimeout: Duration?): TimeoutOracle {
+    return { methodSpec ->
+        when (methodSpec.streamType) {
+            StreamType.UNARY -> unaryTimeout
+            else -> streamTimeout
+        }
+    }
+}
 
 /**
  *  Set of configuration used to set up clients.
  */
 class ProtocolClientConfig @JvmOverloads constructor(
+    // TODO: Use a block-based construction pattern instead of JvmOverloads
+    //       so we can add new fields in the future without having to worry
+    //       about their ordering or potentially breaking compatibility with
+    //       already-compiled byte code.
+
     // The host (e.g., https://connectrpc.com).
     val host: String,
     // The client to use for performing requests.
@@ -54,6 +76,14 @@ class ProtocolClientConfig @JvmOverloads constructor(
     // blocking will automatically be dispatched using the given context,
     // so the caller does not need to worry about it.
     val ioCoroutineContext: CoroutineContext? = null,
+    // A function that is consulted to determine timeouts for each RPC. If
+    // the function returns null, no timeout is applied. If a non-null value
+    // is returned, the entire call must complete before it elapses. If the
+    // call is still active at the end of the timeout period, it is cancelled
+    // and will result in an exception with a Code.DEADLINE_EXCEEDED code.
+    val timeoutOracle: TimeoutOracle = { null },
+    // Schedules timeout actions.
+    val timeoutScheduler: Timeout.Scheduler = Timeout.DEFAULT_SCHEDULER,
 ) {
     private val internalInterceptorFactoryList = mutableListOf<(ProtocolClientConfig) -> Interceptor>()
     private val compressionPools = mutableMapOf<String, CompressionPool>()

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPClientInterface.kt
@@ -17,6 +17,7 @@ package com.connectrpc.http
 import com.connectrpc.StreamResult
 import okio.Buffer
 
+/** A function that cancels an operation when called. */
 typealias Cancelable = () -> Unit
 
 /**

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
@@ -18,6 +18,7 @@ import com.connectrpc.Headers
 import com.connectrpc.MethodSpec
 import okio.Buffer
 import java.net.URL
+import kotlin.time.Duration
 
 enum class HTTPMethod(
     val string: String,
@@ -34,6 +35,8 @@ open class HTTPRequest internal constructor(
     val url: URL,
     // Value to assign to the `content-type` header.
     val contentType: String,
+    // The optional timeout for this request.
+    val timeout: Duration?,
     // Additional outbound headers for the request.
     val headers: Headers,
     // The method spec associated with the request.
@@ -51,6 +54,8 @@ fun HTTPRequest.clone(
     url: URL = this.url,
     // Value to assign to the `content-type` header.
     contentType: String = this.contentType,
+    // The optional timeout for this request.
+    timeout: Duration? = this.timeout,
     // Additional outbound headers for the request.
     headers: Headers = this.headers,
     // The method spec associated with the request.
@@ -59,6 +64,7 @@ fun HTTPRequest.clone(
     return HTTPRequest(
         url,
         contentType,
+        timeout,
         headers,
         methodSpec,
     )
@@ -73,6 +79,8 @@ class UnaryHTTPRequest(
     url: URL,
     // Value to assign to the `content-type` header.
     contentType: String,
+    // The optional timeout for this request.
+    timeout: Duration?,
     // Additional outbound headers for the request.
     headers: Headers,
     // The method spec associated with the request.
@@ -82,13 +90,15 @@ class UnaryHTTPRequest(
     // HTTP method to use with the request.
     // Almost always POST, but side effect free unary RPCs may be made with GET.
     val httpMethod: HTTPMethod = HTTPMethod.POST,
-) : HTTPRequest(url, contentType, headers, methodSpec)
+) : HTTPRequest(url, contentType, timeout, headers, methodSpec)
 
 fun UnaryHTTPRequest.clone(
     // The URL for the request.
     url: URL = this.url,
     // Value to assign to the `content-type` header.
     contentType: String = this.contentType,
+    // The optional timeout for this request.
+    timeout: Duration? = this.timeout,
     // Additional outbound headers for the request.
     headers: Headers = this.headers,
     // The method spec associated with the request.
@@ -101,6 +111,7 @@ fun UnaryHTTPRequest.clone(
     return UnaryHTTPRequest(
         url,
         contentType,
+        timeout,
         headers,
         methodSpec,
         message,

--- a/library/src/main/kotlin/com/connectrpc/http/Timeout.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/Timeout.kt
@@ -1,0 +1,86 @@
+// Copyright 2022-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.connectrpc.http
+
+import kotlinx.coroutines.delay
+import java.util.Timer
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.timerTask
+import kotlin.time.Duration
+
+/**
+ * Represents the timeout state for an RPC.
+ */
+class Timeout private constructor(
+    private val timeoutAction: Cancelable,
+) {
+    private val done = AtomicBoolean(false)
+
+    @Volatile private var triggered: Boolean = false
+    private var onCancel: Cancelable? = null
+
+    /** Returns true if this timeout has lapsed and the associated RPC canceled. */
+    val timedOut: Boolean
+        get() = triggered
+
+    /**
+     * Cancels the timeout. Should only be called when the RPC completes before the
+     * timeout elapses. Returns true if the timeout was canceled or false if either
+     * it was already previously canceled or has already timed out. The `timedOut`
+     * property can be queried to distinguish between these two possibilities.
+     */
+    fun cancel(): Boolean {
+        if (done.compareAndSet(false, true)) {
+            onCancel?.invoke()
+            return true
+        }
+        return false
+    }
+
+    private fun trigger() {
+        if (done.compareAndSet(false, true)) {
+            triggered = true
+            timeoutAction()
+        }
+    }
+
+    /** Schedules timeouts for RPCs. */
+    interface Scheduler {
+        /**
+         * Schedules a timeout that should invoke the given action to cancel
+         * an RPC after the given delay.
+         */
+
+        fun scheduleTimeout(delay: Duration, action: Cancelable): Timeout
+    }
+
+    companion object {
+        /**
+         * A default implementation that a Timer backed by a single daemon thread.
+         * The thread isn't started until the first cancelation is scheduled.
+         */
+        val DEFAULT_SCHEDULER = object : Scheduler {
+            override fun scheduleTimeout(delay: Duration, action: Cancelable): Timeout {
+                val timeout = Timeout(action)
+                val task = timerTask { timeout.trigger() }
+                timer.value.schedule(task, delay.inWholeMilliseconds)
+                timeout.onCancel = { task.cancel() }
+                return timeout
+            }
+        }
+
+        private val timer = lazy { Timer(Scheduler::class.qualifiedName, true) }
+    }
+}

--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectConstants.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectConstants.kt
@@ -21,6 +21,7 @@ const val CONNECT_STREAMING_CONTENT_ENCODING = "connect-content-encoding"
 const val CONNECT_STREAMING_ACCEPT_ENCODING = "connect-accept-encoding"
 const val CONNECT_PROTOCOL_VERSION_KEY = "connect-protocol-version"
 const val CONNECT_PROTOCOL_VERSION_VALUE = "1"
+const val CONNECT_TIMEOUT_MS = "connect-timeout-ms"
 
 const val GRPC_ACCEPT_ENCODING = "grpc-accept-encoding"
 const val GRPC_ENCODING = "grpc-encoding"
@@ -29,6 +30,7 @@ const val GRPC_STATUS_DETAILS_TRAILERS = "grpc-status-details-bin"
 const val GRPC_STATUS_TRAILER = "grpc-status"
 const val GRPC_TE_HEADER = "te"
 const val GRPC_WEB_USER_AGENT = "x-user-agent"
+const val GRPC_TIMEOUT = "grpc-timeout"
 
 const val USER_AGENT = "user-agent"
 

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -76,7 +76,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_unary() {
-        val response = unaryChain.requestFunction(UnaryHTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), UNARY_METHOD_SPEC, Buffer()))
+        val response = unaryChain.requestFunction(UnaryHTTPRequest(URL("https://connectrpc.com"), "", null, emptyMap(), UNARY_METHOD_SPEC, Buffer()))
         assertThat(response.headers["id"]).containsExactly("1", "2", "3", "4")
     }
 
@@ -88,7 +88,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_stream() {
-        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), STREAM_METHOD_SPEC))
+        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", null, emptyMap(), STREAM_METHOD_SPEC))
         assertThat(request.headers["id"]).containsExactly("1", "2", "3", "4")
     }
 

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -39,6 +39,8 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.URL
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class ConnectInterceptorTest {
     private val errorDetailParser: ErrorDetailParser = mock { }
@@ -72,6 +74,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = 2.5.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -104,6 +107,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("User-Agent" to listOf("custom-user-agent")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -132,6 +136,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
@@ -160,6 +165,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
@@ -189,6 +195,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -363,6 +370,7 @@ class ConnectInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -395,6 +403,7 @@ class ConnectInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("User-Agent" to listOf("custom-user-agent")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -423,6 +432,7 @@ class ConnectInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -685,6 +695,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
@@ -722,6 +733,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
@@ -751,6 +763,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(
@@ -785,6 +798,7 @@ class ConnectInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer().write(ByteArray(5_000)),
                 methodSpec = MethodSpec(

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -88,6 +88,7 @@ class ConnectInterceptorTest {
         assertThat(request.headers[CONNECT_PROTOCOL_VERSION_KEY]).containsExactly(CONNECT_PROTOCOL_VERSION_VALUE)
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
         assertThat(request.headers[CONTENT_ENCODING]).isNullOrEmpty()
+        assertThat(request.headers[CONNECT_TIMEOUT_MS]).containsExactly("2500")
         assertThat(request.headers["key"]).containsExactly("value")
         assertThat(request.contentType).isEqualTo("content_type")
         assertThat(request.headers[USER_AGENT]).containsExactly("connect-kotlin/dev")

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -38,6 +38,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.URL
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class GRPCInterceptorTest {
 
@@ -67,6 +69,7 @@ class GRPCInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = 2.5.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -96,6 +99,7 @@ class GRPCInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value"), "User-Agent" to listOf("my-custom-user-agent")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -124,6 +128,7 @@ class GRPCInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
@@ -153,6 +158,7 @@ class GRPCInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = emptyMap(),
                 message = GzipCompressionPool.compress(Buffer().write("message".encodeUtf8())),
                 methodSpec = MethodSpec(
@@ -311,6 +317,7 @@ class GRPCInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = null,
                 headers = mapOf(
                     // Doesn't get passed as headers.
                     GRPC_ENCODING to listOf("gzip"),
@@ -344,6 +351,7 @@ class GRPCInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = null,
                 headers = mapOf("User-Agent" to listOf("custom-user-agent")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -371,6 +379,7 @@ class GRPCInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 methodSpec = MethodSpec(
                     path = "",

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -82,6 +82,7 @@ class GRPCInterceptorTest {
         )
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
         assertThat(request.headers[CONTENT_ENCODING]).isNullOrEmpty()
+        assertThat(request.headers[GRPC_TIMEOUT]).containsExactly("2500m")
         assertThat(request.headers["key"]).containsExactly("value")
         assertThat(request.contentType).isEqualTo("application/grpc+${serializationStrategy.serializationName()}")
     }

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -65,7 +65,7 @@ class GRPCWebInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
-                timeout = 2.25.toDuration(DurationUnit.SECONDS),
+                timeout = 2.5.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -78,6 +78,7 @@ class GRPCWebInterceptorTest {
         )
         assertThat(request.headers[ACCEPT_ENCODING]).isNullOrEmpty()
         assertThat(request.headers[CONTENT_ENCODING]).isNullOrEmpty()
+        assertThat(request.headers[GRPC_TIMEOUT]).containsExactly("2500m")
         assertThat(request.headers["key"]).containsExactly("value")
         assertThat(request.contentType).isEqualTo("application/grpc-web+${serializationStrategy.serializationName()}")
         assertThat(request.headers[GRPC_WEB_USER_AGENT]).containsExactly("grpc-kotlin-connect/dev")
@@ -361,7 +362,6 @@ class GRPCWebInterceptorTest {
             ),
         )
         assertThat(request.contentType).isEqualTo("application/grpc-web+${serializationStrategy.serializationName()}")
-        assertThat(request.headers.keys).containsExactlyInAnyOrder(GRPC_WEB_USER_AGENT, GRPC_ENCODING, "key")
         assertThat(request.headers[GRPC_WEB_USER_AGENT]).containsExactly("grpc-kotlin-connect/dev")
         assertThat(request.headers[GRPC_ENCODING]).containsExactly(GzipCompressionPool.name())
         assertThat(request.headers["key"]).containsExactly("value")

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.URL
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class GRPCWebInterceptorTest {
 
@@ -63,6 +65,7 @@ class GRPCWebInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = 2.25.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -93,6 +96,7 @@ class GRPCWebInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = null,
                 headers = mapOf("X-User-Agent" to listOf("custom-user-agent")),
                 message = Buffer(),
                 methodSpec = MethodSpec(
@@ -121,6 +125,7 @@ class GRPCWebInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
@@ -150,6 +155,7 @@ class GRPCWebInterceptorTest {
             UnaryHTTPRequest(
                 url = URL(config.host),
                 contentType = "",
+                timeout = null,
                 headers = emptyMap(),
                 message = Buffer().write("message".encodeUtf8()),
                 methodSpec = MethodSpec(
@@ -344,6 +350,7 @@ class GRPCWebInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -375,6 +382,7 @@ class GRPCWebInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("X-User-Agent" to listOf("custom-user-agent")),
                 methodSpec = MethodSpec(
                     path = "",
@@ -402,6 +410,7 @@ class GRPCWebInterceptorTest {
             HTTPRequest(
                 url = URL(config.host),
                 contentType = "content_type",
+                timeout = null,
                 headers = mapOf("key" to listOf("value")),
                 methodSpec = MethodSpec(
                     path = "",

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -49,6 +49,8 @@ import java.net.SocketTimeoutException
  */
 class ConnectOkHttpClient @JvmOverloads constructor(
     unaryClient: OkHttpClient = OkHttpClient(),
+    // TODO: remove this; a separate client is only useful for configuring separate timeouts,
+    //       but that can be done in the ProtocolClientConfig instead of the HTTP client.
     streamClient: OkHttpClient = unaryClient,
 ) : HTTPClientInterface {
     private val unaryClient = applyNetworkInterceptor(unaryClient)
@@ -59,8 +61,8 @@ class ConnectOkHttpClient @JvmOverloads constructor(
             .addNetworkInterceptor(object : Interceptor {
                 override fun intercept(chain: Interceptor.Chain): Response {
                     val resp = chain.proceed(chain.request())
-                    // The Connect protocol spec currently suggests 408 as the HTTP status code for
-                    // cancelled and deadline exceeded errors with unary methods.. However, the
+                    // The Connect protocol spec currently suggests 408 as the HTTP status code
+                    // for canceled and deadline exceeded errors with unary methods. However, the
                     // spec for this status code states that the request may be retried without
                     // modification (even non-idempotent requests), and okhttp does in fact retry
                     // such errors. (So do many browsers.) So if we see that error code AND an


### PR DESCRIPTION
This moves the timeout enforcement out of the HTTPClientInterface and into the ProtocolClientInterface. This is more appropriate so that the protocol implementations can be aware of the timeout and add a timeout header, to propagate the deadline to the server.

I've broken it up into a sequence of commits that hopefully makes it easier to review.

I tried looking into making the timeout scheduler coroutine-aware. But this caused issues. Even though I could propagate the `CoroutineScope` from the caller, when invoked from a unary suspend function or a stream function, the issue is how `CoroutineScope.launch` impacts the scope lifetime. In particular, a scope can't complete until all of its children complete, so I was running into issues where code was incorrectly blocking on that child coroutine (which was just doing `delay` for the full timeout period) to end.

I didn't debug it enough to get to bedrock regarding where the blocking was happening or exactly why (naively, I would have expected the timeout coroutine to just be a part of the main coroutine scope create in the initial `runBlocking` in the conformance client, which shouldn't cause the blocking issues I observed 🤷).

So using a simpler Timer seemed like the next best thing. And an alternative like this was needed anyway to be called from non-suspend functions like the callback and blocking unary signatures (for which there is no parent coroutine scope in which to launch a new coroutine).

Resolves #249.