### PR TITLE
Determine protoc version from protobuf version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ CACHE := .tmp/cache
 LICENSE_HEADER_YEAR_RANGE := 2022-2023
 LICENSE_HEADER_VERSION := v1.34.0
 CONFORMANCE_VERSION := v1.0.2
-PROTOC_VERSION ?= 27.2
+PROTOC_VERSION ?= $(shell yq '.versions.protobuf' gradle/libs.versions.toml | cut -d'.' -f2-)
+ifeq ($(PROTOC_VERSION),)
+$(error "Unable to determine protoc version")
+endif
 GRADLE_ARGS ?=
 PROTOC := $(BIN)/protoc
 CONNECT_CONFORMANCE := $(BIN)/connectconformance

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ mavenplugin = "0.29.0"
 moshi = "1.15.1"
 okhttp = "4.12.0"
 okio = "3.9.0"
-# Ensure that PROTOC_VERSION in the Makefile is updated when changing this version.
 protobuf = "4.27.2"
 slf4j = "2.0.13"
 spotless = "6.25.0"


### PR DESCRIPTION
The protoc version is the same value as the '[versions] protobuf' in the Gradle version catalog, without the major version. Update the Makefile to automatically keep these versions in sync, removing a manual step of updating the Makefile whenever dependabot updates protobuf.
