### PR TITLE
Update connect-kotlin to target kotlin 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,8 +133,8 @@ subprojects {
     tasks.withType<KotlinJvmCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
-            languageVersion.set(KotlinVersion.KOTLIN_1_7)
-            apiVersion.set(KotlinVersion.KOTLIN_1_7)
+            languageVersion.set(KotlinVersion.KOTLIN_1_8)
+            apiVersion.set(KotlinVersion.KOTLIN_1_8)
             if (JavaVersion.current().isJava9Compatible && project.name != "android") {
                 freeCompilerArgs.add("-Xjdk-release=1.8")
             }


### PR DESCRIPTION
Kotlin 1.6 and 1.7 are now marked deprecated in [KT-60521](https://youtrack.jetbrains.com/issue/KT-60521). Update connect-kotlin to target Kotlin 1.8.
