### PR TITLE
Build CI using Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - uses: bufbuild/buf-setup-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3


### PR DESCRIPTION
The library continues to be compatible with Java 8, however update to use the latest LTS to build/release. This will ensure we keep ahead of future Gradle and plugin releases which require newer versions (Gradle 9 will require Java 17).
