### PR TITLE
Fix CI and release workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
-          github_token: ${{ github.token }}
+          setup_only: true
       - name: Generate proto files for project
         run: make generate
       - name: Print diff
@@ -53,9 +53,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
-          github_token: ${{ github.token }}
+          setup_only: true
       - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
@@ -112,9 +112,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
-          github_token: ${{ github.token }}
+          setup_only: true
       - name: Run tests
         run: make test
   lint:
@@ -126,8 +126,8 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
-          github_token: ${{ github.token }}
+          setup_only: true
       - name: Run lint
         run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
-          github_token: ${{ github.token }}
+          setup_only: true
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Configure GPG signing & publish
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
@@ -55,7 +55,7 @@ jobs:
           java-version: '21'
           cache: 'gradle'
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: sha256
         run: |
           tag=$(git describe --tags --abbrev=0 --exact-match)
@@ -66,7 +66,7 @@ jobs:
           mv ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin-${release_version}.jar .
           sha256sum protoc-gen-connect-kotlin-${release_version}.jar >> sha256.txt
       - name: Publish GitHub artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           generate_release_notes: true
           append_body: true

--- a/examples/android/build.gradle.kts
+++ b/examples/android/build.gradle.kts
@@ -11,7 +11,6 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-        multiDexEnabled = true
     }
 
     compileOptions {
@@ -25,7 +24,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.constraintLayout)
     implementation(libs.androidx.recyclerview)
-    implementation(libs.android.multidex)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.android.material)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ spotless = "8.3.0"
 [libraries]
 android = { module = "com.google.android:android", version.ref = "android" }
 android-material = { module = "com.google.android.material:material", version = "1.13.0" }
-android-multidex = { module = "com.android.support:multidex", version = "1.0.3" }
 android-plugin = { module = "com.android.tools.build:gradle", version = "9.1.0" }
 androidx-annotations = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }


### PR DESCRIPTION
Update to the newer buf-action and gradle actions. Pin all third party actions. Remove old multidex dependency not needed in newer android versions.