### PR TITLE
Standardize GET encoding across clients

### DIFF
--- a/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ConnectInterceptor.kt
@@ -361,14 +361,19 @@ internal class ConnectInterceptor(
     ): Url {
         // The httpRequest.url already contains the full path including methodSpec.path
         // (added by ProtocolClient.urlFromMethodSpec), so we just need to add query parameters.
+        // Parameters are appended in the order recommended by the Connect protocol to
+        // maximize cache hit rates on shared caches:
+        // [connect] [base64] [compression] encoding message
+        // See https://connectrpc.com/docs/protocol#unary-request.
         return URLBuilder(httpRequest.url).apply {
+            parameters.append(GETConstants.CONNECT_VERSION_QUERY_PARAM_KEY, GETConstants.CONNECT_VERSION_QUERY_PARAM_VALUE)
+            parameters.append(GETConstants.BASE64_QUERY_PARAM_KEY, "1")
             if (requestCompression?.shouldCompress(payload) == true) {
                 parameters.append(GETConstants.COMPRESSION_QUERY_PARAM_KEY, requestCompression.compressionPool.name())
             }
-            parameters.append(GETConstants.MESSAGE_QUERY_PARAM_KEY, payload.readByteString().base64Url())
-            parameters.append(GETConstants.BASE64_QUERY_PARAM_KEY, "1")
             parameters.append(GETConstants.ENCODING_QUERY_PARAM_KEY, codec.encodingName())
-            parameters.append(GETConstants.CONNECT_VERSION_QUERY_PARAM_KEY, GETConstants.CONNECT_VERSION_QUERY_PARAM_VALUE)
+            // Use unpadded base64 URL encoding
+            parameters.append(GETConstants.MESSAGE_QUERY_PARAM_KEY, payload.readByteString().base64Url().trimEnd('='))
         }.build()
     }
 

--- a/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/ConnectInterceptorTest.kt
@@ -715,6 +715,12 @@ class ConnectInterceptorTest {
         assertThat(queryMap.get(GETConstants.ENCODING_QUERY_PARAM_KEY)).isEqualTo("encoding_name")
         assertThat(queryMap.get(GETConstants.CONNECT_VERSION_QUERY_PARAM_KEY)).isEqualTo("v1")
         assertThat(request.httpMethod).isEqualTo(HTTPMethod.GET)
+        assertThat(parseQueryOrder(request)).containsExactly(
+            GETConstants.CONNECT_VERSION_QUERY_PARAM_KEY,
+            GETConstants.BASE64_QUERY_PARAM_KEY,
+            GETConstants.ENCODING_QUERY_PARAM_KEY,
+            GETConstants.MESSAGE_QUERY_PARAM_KEY,
+        )
     }
 
     @Test
@@ -852,11 +858,15 @@ class ConnectInterceptorTest {
     private fun parseQuery(request: HTTPRequest) = request.url.encodedQuery
         .split("&")
         .map { str ->
-            val split = str.split("=")
+            val split = str.split("=", limit = 2)
             split[0] to split[1]
         }
         .foldRight(mutableMapOf<String, String>()) { pair, acc ->
             acc.put(pair.first, pair.second)
             acc
         }
+
+    private fun parseQueryOrder(request: HTTPRequest): List<String> = request.url.encodedQuery
+        .split("&")
+        .map { it.substringBefore("=") }
 }


### PR DESCRIPTION
Update to use the recommended order for query parameters when issuing GET requests and use unpadding base64 URL encoding (matches Swift, ES).