### PR TITLE
Update compile/target sdk and fix AGP warnings

### DIFF
--- a/examples/android/build.gradle.kts
+++ b/examples/android/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.connectrpc.examples.android"
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
@@ -9,4 +8,3 @@ SONATYPE_CLOSE_TIMEOUT_SECONDS=900
 RELEASE_SIGNING_ENABLED=true
 skipAndroid=false
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false


### PR DESCRIPTION
Newer dependencies (like okhttp) require that we compile to a later SDK. Fix two AGP warnings for deprecated settings which will go away in the next release.
