### PR TITLE
Upgrade to kotlin 2.4 compiler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,8 +104,8 @@ subprojects {
     tasks.withType<KotlinJvmCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
-            languageVersion.set(KotlinVersion.KOTLIN_2_1)
-            apiVersion.set(KotlinVersion.KOTLIN_2_1)
+            languageVersion.set(KotlinVersion.KOTLIN_2_2)
+            apiVersion.set(KotlinVersion.KOTLIN_2_2)
             if (JavaVersion.current().isJava9Compatible && project.name != "android") {
                 freeCompilerArgs.add("-Xjdk-release=1.8")
             }

--- a/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
+++ b/conformance/client/google-java/src/main/kotlin/com/connectrpc/conformance/client/java/JavaHelpers.kt
@@ -61,7 +61,6 @@ class JavaHelpers {
             return when (codec) {
                 ClientCompatRequest.Codec.PROTO -> GoogleJavaProtobufStrategy()
                 ClientCompatRequest.Codec.JSON -> GoogleJavaJSONStrategy(getTypes())
-                else -> throw RuntimeException("unsupported codec $codec")
             }
         }
 

--- a/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/VerbosePrinter.kt
+++ b/conformance/client/src/main/kotlin/com/connectrpc/conformance/client/VerbosePrinter.kt
@@ -33,7 +33,7 @@ class VerbosePrinter(
          * threads printing don't interleave optional stack traces
          * (which makes them much harder to read)
          */
-        private val lock = Object()
+        private val lock = Any()
     }
 
     private val output = PrinterImpl(verbosity, prefix)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coroutines = "1.11.0"
 ktor = "3.5.1"
 dokka = "2.2.0"
 junit = "4.13.2"
-kotlin = "2.2.21"
+kotlin = "2.4.10"
 kotlinpoet = "2.3.0"
 mavenplugin = "0.37.0"
 moshi = "1.15.2"
@@ -52,5 +52,5 @@ spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.re
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-ksp = { id = "com.google.devtools.ksp", version = "2.3.3" }
+ksp = { id = "com.google.devtools.ksp", version = "2.3.10" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/com/connectrpc/protocols/ErrorJSONModels.kt
@@ -15,26 +15,25 @@
 package com.connectrpc.protocols
 
 import com.connectrpc.Headers
-import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal class ErrorPayloadJSON(
-    @Json(name = "code") val code: String?,
-    @Json(name = "message") val message: String?,
-    @Json(name = "details") val details: List<ErrorDetailPayloadJSON>?,
+    val code: String?,
+    val message: String?,
+    val details: List<ErrorDetailPayloadJSON>?,
 )
 
 @JsonClass(generateAdapter = true)
 internal class ErrorDetailPayloadJSON(
-    @Json(name = "type") val type: String?,
-    @Json(name = "value") val value: String?,
+    val type: String?,
+    val value: String?,
 )
 
 @JsonClass(generateAdapter = true)
 internal class EndStreamResponseJSON(
-    @Json(name = "error") val error: ErrorPayloadJSON?,
-    @Json(name = "metadata") val metadata: Headers?,
+    val error: ErrorPayloadJSON?,
+    val metadata: Headers?,
 )
 
 internal fun contentTypeIsJSON(contentType: String): Boolean {

--- a/library/src/test/kotlin/com/connectrpc/impl/UnaryCallTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/impl/UnaryCallTest.kt
@@ -27,7 +27,7 @@ class UnaryCallTest {
     fun testExecute() {
         val executor = Executors.newSingleThreadExecutor()
         try {
-            val result = Object()
+            val result = Any()
             val call = UnaryCall<Any> { callback ->
                 executor.execute {
                     callback.invoke(


### PR DESCRIPTION
Update to the kotlin 2.4 compiler, and bump API/language version to 2.2 (keeping with Kotlin's support for the last N-2 releases). Fix warnings from the upgrade.